### PR TITLE
42 implementing api access controll with lti

### DIFF
--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -5,8 +5,6 @@ import errors as err
 from flask_cors import CORS, cross_origin
 import re
 from utils import constants as cons
-from utils.auth.auth import authorize
-from utils.auth.permissions import Permissions
 
 app = Flask(__name__)
 CORS(app, supports_credentials=True)
@@ -42,7 +40,6 @@ def handle_exception(err):
 # User Administration via LMS
 @app.route("/lms/user", methods=['POST'])
 @cross_origin(supports_credentials=True)
-@authorize(Permissions.ADMIN)
 def create_user():
     method = request.method
     match method:

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -5,6 +5,8 @@ import errors as err
 from flask_cors import CORS, cross_origin
 import re
 from utils import constants as cons
+from utils.auth.auth import authorize
+from utils.auth.permissions import Permissions
 
 app = Flask(__name__)
 CORS(app, supports_credentials=True)
@@ -40,6 +42,7 @@ def handle_exception(err):
 # User Administration via LMS
 @app.route("/lms/user", methods=['POST'])
 @cross_origin(supports_credentials=True)
+@authorize(Permissions.ADMIN)
 def create_user():
     method = request.method
     match method:

--- a/errors.py
+++ b/errors.py
@@ -67,3 +67,13 @@ class NoValidParameterValueError(Exception):
 class NoLearningElementsError(Exception):
     code = 400
     description = "There are no learning elements for this topic!"
+
+
+class UnauthorizedError(Exception):
+    code = 401
+    description = "You are not authorized to perform this action!"
+
+
+class StateNotMatchingError(Exception):
+    code = 401
+    description = "The state does not match the state in the cookie!"

--- a/service_layer/crypto/JWTKeyManagement.py
+++ b/service_layer/crypto/JWTKeyManagement.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+
+class JWTKeyManagement(ABC):
+
+    @staticmethod
+    def verify_jwt(jwt: str) -> dict:
+        raise NotImplementedError
+
+    @staticmethod
+    def verify_jwt_payload(jwt_payload, verify_nonce=True) -> bool:
+        raise NotImplementedError

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from flask import Flask
+from werkzeug.exceptions import Unauthorized
+from utils.auth.permissions import Permissions
+from utils.auth.auth import authorize
+from service_layer.crypto.JWTKeyManagement import JWTKeyManagement
+
+
+class TestAuthorizeDecorator(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_authorized_user(self):
+        state = {'permissions': [Permissions.READ.value]}
+        # Mock the request object
+        with self.app.test_request_context():
+            with patch.multiple(JWTKeyManagement,
+                                verify_jwt=MagicMock(return_value=state),
+                                verify_jwt_payload=MagicMock(
+                                    return_value=True)):
+                # Define a test route that requires READ permission
+                @self.app.route('/test')
+                @authorize([Permissions.READ])
+                def test_route(state):
+                    return 'Success'
+
+                # Make a request with a valid JWT
+                c = self.app.test_client()
+                c.set_cookie('haski_state', 'haski_state')  # '' is not None
+                response = c.get('/test')
+                # Assert that the response is successful
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data, b'Success')
+
+    def test_unauthorized_user(self):
+        state = {'permissions': []}
+        # Mock the request object
+        with self.app.test_request_context():
+            with patch.multiple(JWTKeyManagement,
+                                verify_jwt=MagicMock(return_value=state),
+                                verify_jwt_payload=MagicMock(
+                                    return_value=True)):
+                # Define a test route that requires READ permission
+                @self.app.route('/test')
+                @authorize([Permissions.READ])
+                def test_route(state):
+                    return 'Success'
+
+                # Make a request with an invalid JWT
+                c = self.app.test_client()
+                c.set_cookie('haski_state', 'haski_state')
+                response = c.get('/test')
+
+                self.assertEqual(response.status_code, 401)

--- a/utils/auth/auth.py
+++ b/utils/auth/auth.py
@@ -3,7 +3,7 @@ import errors as err
 from flask import request
 from werkzeug.exceptions import Unauthorized
 from service_layer.crypto.JWTKeyManagement import JWTKeyManagement
-from permissions import Permissions
+from utils.auth.permissions import Permissions
 
 
 def authorize(required_permissions: list[Permissions]):

--- a/utils/auth/auth.py
+++ b/utils/auth/auth.py
@@ -1,0 +1,39 @@
+from functools import wraps
+import errors as err
+from flask import request
+from werkzeug.exceptions import Unauthorized
+from service_layer.crypto.JWTKeyManagement import JWTKeyManagement
+from permissions import Permissions
+
+
+def authorize(required_permissions: list[Permissions]):
+    '''🔑 Decorator for checking if user has the required \
+        permission to access the endpoint.
+        Example usage:
+        @app.route('/api/endpoint')
+        @authorize([Permissions.READ, Permissions.WRITE])
+        def endpoint():'''
+
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kws):
+            state_jwt = request.cookies.get('haski_state')
+            if state_jwt is None:
+                raise err.StateNotMatchingError()
+
+            state = JWTKeyManagement.verify_jwt(state_jwt)
+            if not JWTKeyManagement.verify_jwt_payload(state,
+                                                       verify_nonce=False):
+                raise err.UnauthorizedError()
+
+            # Check if user has any of the required permissions
+            user_permissions: list[str] = state.get('permissions', [])
+            if not all(permission.value in user_permissions
+                       for permission in required_permissions):
+                raise Unauthorized(
+                    'You do not have the necessary permissions to perform \
+                        this action')
+
+            return f(state, *args, **kws)
+        return decorated_function
+    return decorator

--- a/utils/auth/permissions.py
+++ b/utils/auth/permissions.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class Permissions(Enum):
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    ADMIN = "admin"
+    # add other permissions as needed


### PR DESCRIPTION
###  Authorize feature: Add permission-based access control
Closes #42
## Description
This pull request adds an authorization feature to the application, allowing for permission-based access control for our endpoints. We've defined a decorator, `authorize()`, that checks if a user has a cookie `haski_state` containing the necessary permissions to access a particular endpoint. If they do not, an Unauthorized error is raised.
**Example usage:**
```python
from flask import Flask
from utils.auth.auth import authorize
from utils.auth.permissions import Permissions

app = Flask(__name__)

@app.route('/secure_endpoint')
@authorize([Permissions.READ])
def secure_endpoint(state):
    # Your secure endpoint logic goes here
    return 'Secure data'
```

Permissions are represented as a list of Permissions enum values.

## Changes
Added the authorize decorator in _utils/auth/auth.py_
Added unit tests for the authorize decorator in _tests/unit/test_auth.py_
## Testing
Unit tests have been added to ensure the authorize decorator works as expected. The tests mock the JWTKeyManagement methods and the flask request object. The decorator is tested with both authorized and unauthorized users.

### Note
The authorize decorator requires a cookie. This feature will be implemented with https://github.com/HASKI-RAK/HASKI-Backend/pull/32
