### PR TITLE
hotfix for deeper nested subdomains

### DIFF
--- a/service_layer/lti/OIDCLoginFlask.py
+++ b/service_layer/lti/OIDCLoginFlask.py
@@ -370,6 +370,10 @@ class OIDCLoginFlask(OIDCLogin):
         )
         # set 🔑 auth 🍪 cookie
         domain = urllib.parse.urlparse(self._request.referrer).hostname
+        if not domain:
+            raise err.ErrorException(message="No domain found", status_code=403)
+        # use only the top domain, for example instead of ke.haski.app use haski.app
+        domain = ".".join(domain.split(".")[-2:])
         secure = True if self._request.referrer.startswith("https") else False
         self._cookie_service.set_cookie(
             response=response,

--- a/tests/unit/lti/test_OIDCLoginFlask.py
+++ b/tests/unit/lti/test_OIDCLoginFlask.py
@@ -13,9 +13,9 @@ config_file = {
     "https://moodle.haski.app": {
         "default": True,
         "client_id": "VRCKkhKlZtHNHtD",
-        "tool_url": "https://backend.haski.app",
-        "frontend_login_url": "https://haski.app/login",
-        "target_link_uri": "https://backend.haski.app/lti_launch",
+        "tool_url": "https://backend.ke.haski.app",
+        "frontend_login_url": "https://ke.haski.app/login",
+        "target_link_uri": "https://backend.ke.haski.app/lti_launch",
         "auth_login_url": "https://moodle.haski.app/mod/lti/auth.php",
         "auth_token_url": "https://moodle.haski.app/mod/lti/token.php",
         "key_set_url": "https://moodle.haski.app/mod/lti/certs.php",
@@ -48,7 +48,7 @@ form = {
     "client_id": "VRCKkhKlZtHNHtD",
     "login_hint": "student",
     "lti_message_hint": "message_hint",
-    "target_link_uri": "https://backend.haski.app/lti_launch",
+    "target_link_uri": "https://backend.ke.haski.app/lti_launch",
     "lti_deployment_id": "1",
 }
 


### PR DESCRIPTION
Problem was that backend from domain: backend.ke.haski.app used the frontend url of ke.haski.app to set a cookie to this domain. But this results in a cross domain cookie. Therefore we now set the cookie to the top domain which includes both frontend and backend.
Closes #70 