### PR TITLE
get all learning element status of a student for a course. Return either all or one specific status

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,20 @@ For checking the code quality, you can use Sonarqube (https://docs.sonarqube.org
 There shouldn't be any code smells left, when contributing to the project.
 
 After a Pull Request, one of the Code Owners will check and give feedback before the merge is possible.
+
+## Moodle
+
+The functionality to send requests to moodle via REST-API needs to be activated in moodle settings. 
+The following settings are necessary, do not forget so save the changes:
+- Active web service protocols: REST protocol (enable)
+- Enable web services: yes
+- Enable web services for mobile devices: yes
+
+Also it is necessary to create a token for a user with admin rights. 
+- Go to Site administration -> Server -> Manage tokens -> Create token
+- Select an admin user and create a token with the Service "Moodle mobile web service", set the validity to your needs and save the token.
+
+Lastly you have to add the following lines to your .flaskenv file:
+- REST_LMS_URL= "yourmoodleurl" (something like https://moodle.haski.de)
+- REST_TOKEN="yourtoken" (something like f5b78d90cff0bf8f61a5745ce1441e87)
+

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -347,7 +347,6 @@ def get_activity_status_for_student(course_id, student_id):
             activity_status = services.get_activity_status_for_student_for_course(
                 unit_of_work.SqlAlchemyUnitOfWork(), course_id, student_id
             )
-            print(activity_status)
             return jsonify(activity_status), 200
 
 

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -337,6 +337,34 @@ def login_credentials(data: Dict[str, Any]):
                 raise err.MissingParameterError()
 
 
+# Endpoint to get activity status for a student for a course
+@app.route("/lms/course/<course_id>/student/<student_id>/activitystatus", methods=["GET"])
+@cross_origin(supports_credentials=True)
+def get_activity_status_for_student(course_id, student_id):
+    method = request.method
+    match method:
+        case "GET":
+            activity_status = services.get_activity_status_for_student_for_course(
+                unit_of_work.SqlAlchemyUnitOfWork(), course_id, student_id
+            )
+            print(activity_status)
+            return jsonify(activity_status), 200
+
+
+# Endpoint to get activity status for a student for a course for a specific learning element
+@app.route("/lms/course/<course_id>/student/<student_id>/learningElementId/<learning_element_id>/activitystatus", methods=["GET"])
+@cross_origin(supports_credentials=True)
+def get_activity_status_for_student_for_learning_element(course_id, student_id, learning_element_id):
+    method = request.method
+    match method:
+        case "GET":
+            activity_status = services.get_activity_status_for_student_for_learning_element_for_course(
+                unit_of_work.SqlAlchemyUnitOfWork(), course_id, student_id, learning_element_id
+            )
+            print(activity_status)
+            return jsonify(activity_status), 200
+
+
 @app.route("/lms/course/<course_id>/<lms_course_id>/topic", methods=["POST"])
 @cross_origin(supports_credentials=True)
 @json_only()

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -355,7 +355,7 @@ def get_activity_status_for_student(course_id, student_id):
 # Endpoint to get activity status for a student, course and specific learning element
 @app.route(
     "/lms/course/<course_id>/student/<student_id>/"
-    +"learningElementId/<learning_element_id>/activitystatus",
+    + "learningElementId/<learning_element_id>/activitystatus",
     methods=["GET"],
 )
 @cross_origin(supports_credentials=True)
@@ -365,13 +365,12 @@ def get_activity_status_for_student_for_learning_element(
     method = request.method
     match method:
         case "GET":
-            activity_status = (services.
-            get_activity_status_for_student_for_learning_element_for_course(
+            activity_status = services.get_activity_status_for_learning_element(
                 unit_of_work.SqlAlchemyUnitOfWork(),
                 course_id,
                 student_id,
                 learning_element_id,
-            ))
+            )
             print(activity_status)
             return jsonify(activity_status), 200
 

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -352,9 +352,10 @@ def get_activity_status_for_student(course_id, student_id):
             return jsonify(activity_status), 200
 
 
-# Endpoint to get activity status for a student for a course for a specific learning element
+# Endpoint to get activity status for a student, course and specific learning element
 @app.route(
-    "/lms/course/<course_id>/student/<student_id>/learningElementId/<learning_element_id>/activitystatus",
+    "/lms/course/<course_id>/student/<student_id>/"
+    +"learningElementId/<learning_element_id>/activitystatus",
     methods=["GET"],
 )
 @cross_origin(supports_credentials=True)
@@ -364,12 +365,13 @@ def get_activity_status_for_student_for_learning_element(
     method = request.method
     match method:
         case "GET":
-            activity_status = services.get_activity_status_for_student_for_learning_element_for_course(
+            activity_status = (services.
+            get_activity_status_for_student_for_learning_element_for_course(
                 unit_of_work.SqlAlchemyUnitOfWork(),
                 course_id,
                 student_id,
                 learning_element_id,
-            )
+            ))
             print(activity_status)
             return jsonify(activity_status), 200
 

--- a/entrypoints/flask_app.py
+++ b/entrypoints/flask_app.py
@@ -338,7 +338,9 @@ def login_credentials(data: Dict[str, Any]):
 
 
 # Endpoint to get activity status for a student for a course
-@app.route("/lms/course/<course_id>/student/<student_id>/activitystatus", methods=["GET"])
+@app.route(
+    "/lms/course/<course_id>/student/<student_id>/activitystatus", methods=["GET"]
+)
 @cross_origin(supports_credentials=True)
 def get_activity_status_for_student(course_id, student_id):
     method = request.method
@@ -351,14 +353,22 @@ def get_activity_status_for_student(course_id, student_id):
 
 
 # Endpoint to get activity status for a student for a course for a specific learning element
-@app.route("/lms/course/<course_id>/student/<student_id>/learningElementId/<learning_element_id>/activitystatus", methods=["GET"])
+@app.route(
+    "/lms/course/<course_id>/student/<student_id>/learningElementId/<learning_element_id>/activitystatus",
+    methods=["GET"],
+)
 @cross_origin(supports_credentials=True)
-def get_activity_status_for_student_for_learning_element(course_id, student_id, learning_element_id):
+def get_activity_status_for_student_for_learning_element(
+    course_id, student_id, learning_element_id
+):
     method = request.method
     match method:
         case "GET":
             activity_status = services.get_activity_status_for_student_for_learning_element_for_course(
-                unit_of_work.SqlAlchemyUnitOfWork(), course_id, student_id, learning_element_id
+                unit_of_work.SqlAlchemyUnitOfWork(),
+                course_id,
+                student_id,
+                learning_element_id,
             )
             print(activity_status)
             return jsonify(activity_status), 200

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1763,6 +1763,7 @@ def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWo
         moodle_course_id = "&courseid=" + str(course[0].lms_id)
         moodle_user_id = "&userid=" + str(student_id)
         moodle_rest_request = moodle_url + moodle_rest + rest_function + rest_token + rest_format + moodle_course_id + moodle_user_id
+        print(requests.get(moodle_rest_request))
         return requests.get(moodle_rest_request)
 
 

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 from flask.wrappers import Request
 
@@ -10,7 +12,6 @@ from domain.tutoringModel import model as TM
 from domain.userAdministartion import model as UA
 from service_layer import unit_of_work
 from service_layer.lti.OIDCLoginFlask import OIDCLoginFlask
-import os
 
 
 def add_course_creator_to_course(

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1753,7 +1753,9 @@ def get_user_by_lms_id(uow: unit_of_work.AbstractUnitOfWork, lms_user_id) -> dic
         return result
 
 
-def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWork, course_id, student_id) -> dict:
+def get_moodle_rest_url_for_completion_status(
+    uow: unit_of_work.AbstractUnitOfWork, course_id, student_id
+) -> dict:
     with uow:
         course = uow.course.get_course_by_id(course_id)
         moodle_url = os.environ.get("REST_LMS_URL", "")
@@ -1763,17 +1765,31 @@ def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWo
         rest_format = "&moodlewsrestformat=json"
         moodle_course_id = "&courseid=" + str(course[0].lms_id)
         moodle_user_id = "&userid=" + str(student_id)
-        moodle_rest_request = moodle_url + moodle_rest + rest_function + rest_token + rest_format + moodle_course_id + moodle_user_id
+        moodle_rest_request = (
+            moodle_url
+            + moodle_rest
+            + rest_function
+            + rest_token
+            + rest_format
+            + moodle_course_id
+            + moodle_user_id
+        )
         return requests.get(moodle_rest_request)
 
 
-def get_activity_status_for_student_for_course(uow: unit_of_work.AbstractUnitOfWork, course_id, student_id) -> dict:
+def get_activity_status_for_student_for_course(
+    uow: unit_of_work.AbstractUnitOfWork, course_id, student_id
+) -> dict:
     with uow:
         response = get_moodle_rest_url_for_completion_status(uow, course_id, student_id)
         if response.status_code == 200:
             json_response = response.json()
             filtered_statuses = [
-                {"cmid": status["cmid"], "state": status["state"], "timecompleted": status["timecompleted"]}
+                {
+                    "cmid": status["cmid"],
+                    "state": status["state"],
+                    "timecompleted": status["timecompleted"],
+                }
                 for status in json_response["statuses"]
             ]
             return filtered_statuses
@@ -1781,10 +1797,18 @@ def get_activity_status_for_student_for_course(uow: unit_of_work.AbstractUnitOfW
             return {}
 
 
-def get_activity_status_for_student_for_learning_element_for_course(uow: unit_of_work.AbstractUnitOfWork, course_id, student_id, learning_element_id) -> dict:
+def get_activity_status_for_student_for_learning_element_for_course(
+    uow: unit_of_work.AbstractUnitOfWork, course_id, student_id, learning_element_id
+) -> dict:
     with uow:
-        filtered_statuses = get_activity_status_for_student_for_course(uow, course_id, student_id)
-        filtered_cmid = [item for item in filtered_statuses if item['cmid'] == int(learning_element_id)]
+        filtered_statuses = get_activity_status_for_student_for_course(
+            uow, course_id, student_id
+        )
+        filtered_cmid = [
+            item
+            for item in filtered_statuses
+            if item["cmid"] == int(learning_element_id)
+        ]
         return filtered_cmid
 
 

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1774,7 +1774,11 @@ def get_moodle_rest_url_for_completion_status(
             + moodle_course_id
             + moodle_user_id
         )
-        return requests.get(moodle_rest_request)
+        response = requests.get(moodle_rest_request)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return response.status_code.json()
 
 
 def get_activity_status_for_student_for_course(

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1797,7 +1797,7 @@ def get_activity_status_for_student_for_course(
             ]
             return filtered_statuses
         else:
-            return {}
+            return []
 
 
 def get_activity_status_for_learning_element(

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1778,23 +1778,22 @@ def get_moodle_rest_url_for_completion_status(
         if response.status_code == 200:
             return response.json()
         else:
-            return response.status_code.json()
+            return {}
 
 
 def get_activity_status_for_student_for_course(
     uow: unit_of_work.AbstractUnitOfWork, course_id, student_id
-) -> dict:
+) -> list:
     with uow:
         response = get_moodle_rest_url_for_completion_status(uow, course_id, student_id)
-        if response.status_code == 200:
-            json_response = response.json()
+        if response != {}:
             filtered_statuses = [
                 {
                     "cmid": status["cmid"],
                     "state": status["state"],
                     "timecompleted": status["timecompleted"],
                 }
-                for status in json_response["statuses"]
+                for status in response["statuses"]
             ]
             return filtered_statuses
         else:
@@ -1803,7 +1802,7 @@ def get_activity_status_for_student_for_course(
 
 def get_activity_status_for_learning_element(
     uow: unit_of_work.AbstractUnitOfWork, course_id, student_id, learning_element_id
-) -> dict:
+) -> list:
     with uow:
         filtered_statuses = get_activity_status_for_student_for_course(
             uow, course_id, student_id

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1797,7 +1797,7 @@ def get_activity_status_for_student_for_course(
             return {}
 
 
-def get_activity_status_for_student_for_learning_element_for_course(
+def get_activity_status_for_learning_element(
     uow: unit_of_work.AbstractUnitOfWork, course_id, student_id, learning_element_id
 ) -> dict:
     with uow:

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1755,7 +1755,7 @@ def get_user_by_lms_id(uow: unit_of_work.AbstractUnitOfWork, lms_user_id) -> dic
 def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWork, course_id, student_id) -> dict:
     with uow:
         course = uow.course.get_course_by_id(course_id)
-        moodle_url = "https://ke.moodle.haski.app" #os.envinron.get("LMS_URL", "")
+        moodle_url = os.environ.get("REST_LMS_URL", "")
         moodle_rest = "/webservice/rest/server.php"
         rest_function = "?wsfunction=core_completion_get_activities_completion_status"
         rest_token = "&wstoken=" + os.environ.get("REST_TOKEN", "")
@@ -1763,7 +1763,7 @@ def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWo
         moodle_course_id = "&courseid=" + str(course[0].lms_id)
         moodle_user_id = "&userid=" + str(student_id)
         moodle_rest_request = moodle_url + moodle_rest + rest_function + rest_token + rest_format + moodle_course_id + moodle_user_id
-        return moodle_rest_request
+        return requests.get(moodle_rest_request)
 
 
 def get_activity_status_for_student_for_course(uow: unit_of_work.AbstractUnitOfWork, course_id, student_id) -> dict:

--- a/service_layer/services.py
+++ b/service_layer/services.py
@@ -1763,7 +1763,6 @@ def get_moodle_rest_url_for_completion_status(uow: unit_of_work.AbstractUnitOfWo
         moodle_course_id = "&courseid=" + str(course[0].lms_id)
         moodle_user_id = "&userid=" + str(student_id)
         moodle_rest_request = moodle_url + moodle_rest + rest_function + rest_token + rest_format + moodle_course_id + moodle_user_id
-        print(requests.get(moodle_rest_request))
         return requests.get(moodle_rest_request)
 
 

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,5 +1,5 @@
 import json
-
+from unittest import mock
 import pytest
 
 user_id_admin = 0
@@ -18,6 +18,7 @@ questionnaire_ils_id = 0
 questionnaire_list_k_id = 0
 
 path_admin = "/admin"
+path_activity_status = "/activitystatus"
 path_course = "/course"
 path_contactform = "/contactform"
 path_knowledge = "/knowledge"
@@ -233,130 +234,130 @@ class TestApi:
         [
             # Working Example Admin
             (
-                {
-                    "name": "Achim Admin",
-                    "lms_user_id": 1,
-                    "role": "Admin",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                [
-                    "id",
-                    "name",
-                    "university",
-                    "lms_user_id",
-                    "role",
-                    "role_id",
-                    "settings",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Achim Admin",
+                        "lms_user_id": 1,
+                        "role": "Admin",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    [
+                        "id",
+                        "name",
+                        "university",
+                        "lms_user_id",
+                        "role",
+                        "role_id",
+                        "settings",
+                    ],
+                    201,
+                    True,
             ),
             # Working Example Course Creator
             (
-                {
-                    "name": "Claus Creator",
-                    "lms_user_id": 2,
-                    "role": "Course Creator",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                [
-                    "id",
-                    "name",
-                    "university",
-                    "lms_user_id",
-                    "role",
-                    "role_id",
-                    "settings",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Claus Creator",
+                        "lms_user_id": 2,
+                        "role": "Course Creator",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    [
+                        "id",
+                        "name",
+                        "university",
+                        "lms_user_id",
+                        "role",
+                        "role_id",
+                        "settings",
+                    ],
+                    201,
+                    True,
             ),
             # Working Example Teacher
             (
-                {
-                    "name": "Tim Teacher",
-                    "lms_user_id": 3,
-                    "role": "Teacher",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                [
-                    "id",
-                    "name",
-                    "university",
-                    "lms_user_id",
-                    "role",
-                    "role_id",
-                    "settings",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Tim Teacher",
+                        "lms_user_id": 3,
+                        "role": "Teacher",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    [
+                        "id",
+                        "name",
+                        "university",
+                        "lms_user_id",
+                        "role",
+                        "role_id",
+                        "settings",
+                    ],
+                    201,
+                    True,
             ),
             # Working Example Student
             (
-                {
-                    "name": "Sonja Studentin",
-                    "lms_user_id": 4,
-                    "role": "Student",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                [
-                    "id",
-                    "name",
-                    "university",
-                    "lms_user_id",
-                    "role",
-                    "role_id",
-                    "settings",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Sonja Studentin",
+                        "lms_user_id": 4,
+                        "role": "Student",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    [
+                        "id",
+                        "name",
+                        "university",
+                        "lms_user_id",
+                        "role",
+                        "role_id",
+                        "settings",
+                    ],
+                    201,
+                    True,
             ),
             # Missing Parameter
             (
-                {
-                    "lms_user_id": 1,
-                    "role": "Student",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "lms_user_id": 1,
+                        "role": "Student",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "name": "Max Mustermann",
-                    "lms_user_id": "1",
-                    "role": "Student",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Max Mustermann",
+                        "lms_user_id": "1",
+                        "role": "Student",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # User already exists
             (
-                {
-                    "name": "Achim Admin",
-                    "lms_user_id": 1,
-                    "role": "Admin",
-                    "university": "TH-AB",
-                    "password": "password",
-                },
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Achim Admin",
+                        "lms_user_id": 1,
+                        "role": "Admin",
+                        "university": "TH-AB",
+                        "password": "password",
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_api_create_user_from_moodle(
-        self, client_class, input, keys_expected, status_code_expected, save_id
+            self, client_class, input, keys_expected, status_code_expected, save_id
     ):
         url = path_lms_user
         r = client_class.post(url, json=input)
@@ -390,51 +391,51 @@ class TestApi:
         [
             # Working Example
             (
-                {
-                    "name": "Test Course",
-                    "lms_id": 1,
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                ["id", "name", "lms_id", "created_at", "created_by", "university"],
-                201,
-                True,
+                    {
+                        "name": "Test Course",
+                        "lms_id": 1,
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    ["id", "name", "lms_id", "created_at", "created_by", "university"],
+                    201,
+                    True,
             ),
             # Missing Parameter
             (
-                {"name": "Test Course", "university": "TH-AB"},
-                ["error", "message"],
-                400,
-                False,
+                    {"name": "Test Course", "university": "TH-AB"},
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "name": "Test Course",
-                    "lms_id": "1",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Course",
+                        "lms_id": "1",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Course already exists
             (
-                {
-                    "name": "Test Course",
-                    "lms_id": 1,
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Course",
+                        "lms_id": 1,
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_api_create_course_from_moodle(
-        self, client_class, input, keys_expected, status_code_expected, save_id
+            self, client_class, input, keys_expected, status_code_expected, save_id
     ):
         global user_id_course_creator
         input["created_by"] = user_id_course_creator
@@ -455,123 +456,123 @@ class TestApi:
         [
             # Working Example for Topic
             (
-                {
-                    "name": "Test Topic",
-                    "lms_id": 1,
-                    "is_topic": True,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                [
-                    "id",
-                    "name",
-                    "lms_id",
-                    "is_topic",
-                    "parent_id",
-                    "contains_le",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Test Topic",
+                        "lms_id": 1,
+                        "is_topic": True,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    [
+                        "id",
+                        "name",
+                        "lms_id",
+                        "is_topic",
+                        "parent_id",
+                        "contains_le",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
+                    True,
             ),
             # Working Example for Sub-Topic
             (
-                {
-                    "name": "Test Sub-Topic",
-                    "lms_id": 2,
-                    "is_topic": False,
-                    "parent_id": 1,
-                    "contains_le": True,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                [
-                    "id",
-                    "name",
-                    "lms_id",
-                    "is_topic",
-                    "parent_id",
-                    "contains_le",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Test Sub-Topic",
+                        "lms_id": 2,
+                        "is_topic": False,
+                        "parent_id": 1,
+                        "contains_le": True,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    [
+                        "id",
+                        "name",
+                        "lms_id",
+                        "is_topic",
+                        "parent_id",
+                        "contains_le",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
+                    True,
             ),
             # Missing Parameter
             (
-                {
-                    "name": "Test Topic",
-                    "is_topic": True,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Topic",
+                        "is_topic": True,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "name": "Test Topic",
-                    "lms_id": "1",
-                    "is_topic": True,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Topic",
+                        "lms_id": "1",
+                        "is_topic": True,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Topic already exists
             (
-                {
-                    "name": "Test Topic",
-                    "lms_id": 1,
-                    "is_topic": True,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Topic",
+                        "lms_id": 1,
+                        "is_topic": True,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_api_create_topic_from_moodle(
-        self,
-        client_class,
-        input,
-        moodle_course_id,
-        keys_expected,
-        status_code_expected,
-        save_id,
+            self,
+            client_class,
+            input,
+            moodle_course_id,
+            keys_expected,
+            status_code_expected,
+            save_id,
     ):
         global course_id, topic_id, sub_topic_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
         )
         if topic_id != 0:
             input["parent_id"] = topic_id
@@ -594,106 +595,106 @@ class TestApi:
         [
             # Working Example for LE
             (
-                {
-                    "lms_id": 1,
-                    "activity_type": "Quiz",
-                    "classification": "RQ",
-                    "name": "Test Learning Element",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
-                True,
+                    {
+                        "lms_id": 1,
+                        "activity_type": "Quiz",
+                        "classification": "RQ",
+                        "name": "Test Learning Element",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
+                    True,
             ),
             # Missing Parameter
             (
-                {
-                    "lms_id": 1,
-                    "classification": "RQ",
-                    "name": "Test Learning Element",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "lms_id": 1,
+                        "classification": "RQ",
+                        "name": "Test Learning Element",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "lms_id": "1",
-                    "activity_type": "Quiz",
-                    "classification": "RQ",
-                    "name": "Test Learning Element",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "lms_id": "1",
+                        "activity_type": "Quiz",
+                        "classification": "RQ",
+                        "name": "Test Learning Element",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # LE already exists
             (
-                {
-                    "lms_id": 1,
-                    "activity_type": "Quiz",
-                    "classification": "RQ",
-                    "name": "Test Learning Element",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "lms_id": 1,
+                        "activity_type": "Quiz",
+                        "classification": "RQ",
+                        "name": "Test Learning Element",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_api_create_le_from_moodle(
-        self,
-        client_class,
-        input,
-        moodle_course_id,
-        moodle_topic_id,
-        keys_expected,
-        status_code_expected,
-        save_id,
+            self,
+            client_class,
+            input,
+            moodle_course_id,
+            moodle_topic_id,
+            keys_expected,
+            status_code_expected,
+            save_id,
     ):
         global course_id
         global sub_topic_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
-            + "/"
-            + str(sub_topic_id)
-            + "/"
-            + str(moodle_topic_id)
-            + path_learning_element
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
+                + "/"
+                + str(sub_topic_id)
+                + "/"
+                + str(moodle_topic_id)
+                + path_learning_element
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -720,12 +721,12 @@ class TestApi:
         ],
     )
     def test_add_teacher_to_course(
-        self,
-        client_class,
-        error_teacher,
-        error_course,
-        keys_expected,
-        status_code_expected,
+            self,
+            client_class,
+            error_teacher,
+            error_course,
+            keys_expected,
+            status_code_expected,
     ):
         global course_id, teacher_id
         if error_teacher:
@@ -737,12 +738,12 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id_use)
-            + path_teacher
-            + "/"
-            + str(teacher_id_use)
+                path_lms_course
+                + "/"
+                + str(course_id_use)
+                + path_teacher
+                + "/"
+                + str(teacher_id_use)
         )
         r = client_class.post(url)
         assert r.status_code == status_code_expected
@@ -757,22 +758,22 @@ class TestApi:
         [
             # Working Example
             (
-                False,
-                False,
-                [
-                    "id",
-                    "course_id",
-                    "student_id",
-                    "input_dimension",
-                    "input_value",
-                    "perception_dimension",
-                    "perception_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                201,
+                    False,
+                    False,
+                    [
+                        "id",
+                        "course_id",
+                        "student_id",
+                        "input_dimension",
+                        "input_value",
+                        "perception_dimension",
+                        "perception_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    201,
             ),
             # Student not found
             (True, False, ["error", "message"], 404),
@@ -783,12 +784,12 @@ class TestApi:
         ],
     )
     def test_add_student_to_course(
-        self,
-        client_class,
-        error_student,
-        error_course,
-        keys_expected,
-        status_code_expected,
+            self,
+            client_class,
+            error_student,
+            error_course,
+            keys_expected,
+            status_code_expected,
     ):
         global course_id, student_id
         if error_student:
@@ -800,12 +801,12 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id_use)
-            + path_student
-            + "/"
-            + str(student_id_use)
+                path_lms_course
+                + "/"
+                + str(course_id_use)
+                + path_student
+                + "/"
+                + str(student_id_use)
         )
         r = client_class.post(url)
         assert r.status_code == status_code_expected
@@ -820,33 +821,33 @@ class TestApi:
         [
             # Working example
             (
-                1,
-                [
-                    "att",
-                    "characteristic_id",
-                    "cogn_str",
-                    "con",
-                    "crit_rev",
-                    "eff",
-                    "elab",
-                    "ext_res_mng_str",
-                    "goal_plan",
-                    "id",
-                    "int_res_mng_str",
-                    "lit_res",
-                    "lrn_env",
-                    "lrn_w_cls",
-                    "metacogn_str",
-                    "org",
-                    "reg",
-                    "rep",
-                    "time",
-                ],
-                201,
-                True,
-                False,
-                False,
-                False,
+                    1,
+                    [
+                        "att",
+                        "characteristic_id",
+                        "cogn_str",
+                        "con",
+                        "crit_rev",
+                        "eff",
+                        "elab",
+                        "ext_res_mng_str",
+                        "goal_plan",
+                        "id",
+                        "int_res_mng_str",
+                        "lit_res",
+                        "lrn_env",
+                        "lrn_w_cls",
+                        "metacogn_str",
+                        "org",
+                        "reg",
+                        "rep",
+                        "time",
+                    ],
+                    201,
+                    True,
+                    False,
+                    False,
+                    False,
             ),
             # Missing mandatory answer
             (1, ["error", "message"], 400, False, True, False, False),
@@ -857,15 +858,15 @@ class TestApi:
         ],
     )
     def test_post_questionnaire_list_k(
-        self,
-        client_class,
-        student_id,
-        keys_expected,
-        status_code_expected,
-        save_id,
-        error_id_missing,
-        error_answer_list_k,
-        error_list_k_id,
+            self,
+            client_class,
+            student_id,
+            keys_expected,
+            status_code_expected,
+            save_id,
+            error_id_missing,
+            error_answer_list_k,
+            error_list_k_id,
     ):
         json_input = {}
         list_k = []
@@ -901,47 +902,47 @@ class TestApi:
         [
             # Working example
             (
-                True,
-                1,
-                [
-                    "characteristic_id",
-                    "id",
-                    "input_dimension",
-                    "input_value",
-                    "perception_dimension",
-                    "perception_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                201,
-                True,
-                False,
-                False,
-                False,
+                    True,
+                    1,
+                    [
+                        "characteristic_id",
+                        "id",
+                        "input_dimension",
+                        "input_value",
+                        "perception_dimension",
+                        "perception_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    201,
+                    True,
+                    False,
+                    False,
+                    False,
             ),
             # Working example short questionnaire
             (
-                False,
-                1,
-                [
-                    "characteristic_id",
-                    "id",
-                    "input_dimension",
-                    "input_value",
-                    "perception_dimension",
-                    "perception_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                201,
-                True,
-                False,
-                False,
-                False,
+                    False,
+                    1,
+                    [
+                        "characteristic_id",
+                        "id",
+                        "input_dimension",
+                        "input_value",
+                        "perception_dimension",
+                        "perception_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    201,
+                    True,
+                    False,
+                    False,
+                    False,
             ),
             # Missing mandatory answer
             (False, 1, ["error", "message"], 400, False, True, False, False),
@@ -952,16 +953,16 @@ class TestApi:
         ],
     )
     def test_post_questionnaire_ils(
-        self,
-        client_class,
-        ils_long,
-        student_id,
-        keys_expected,
-        status_code_expected,
-        save_id,
-        error_id_missing,
-        error_key_wrong,
-        error_answer_ils,
+            self,
+            client_class,
+            ils_long,
+            student_id,
+            keys_expected,
+            status_code_expected,
+            save_id,
+            error_id_missing,
+            error_key_wrong,
+            error_answer_ils,
     ):
         json_input = {}
         ils = []
@@ -1011,10 +1012,10 @@ class TestApi:
         [
             # Working Example
             (
-                {"visit_start": "2023-08-01T13:37:42Z"},
-                4,
-                ["id", "student_id", "topic_id", "visit_start", "visit_end"],
-                201,
+                    {"visit_start": "2023-08-01T13:37:42Z"},
+                    4,
+                    ["id", "student_id", "topic_id", "visit_start", "visit_end"],
+                    201,
             ),
             # Wrong data format
             ({"visit_start": "01.01.2023"}, 4, ["error", "message"], 400),
@@ -1023,18 +1024,18 @@ class TestApi:
         ],
     )
     def test_post_topic_visit(
-        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global student_id, topic_id
         url = (
-            path_lms_student
-            + "/"
-            + str(student_id)
-            + "/"
-            + str(moodle_user_id)
-            + path_topic
-            + "/"
-            + str(topic_id)
+                path_lms_student
+                + "/"
+                + str(student_id)
+                + "/"
+                + str(moodle_user_id)
+                + path_topic
+                + "/"
+                + str(topic_id)
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1049,10 +1050,10 @@ class TestApi:
         [
             # Working Example
             (
-                {"visit_start": "2023-08-01T13:37:42Z"},
-                4,
-                ["student_id", "learning_element_id", "visit_start", "visit_end"],
-                201,
+                    {"visit_start": "2023-08-01T13:37:42Z"},
+                    4,
+                    ["student_id", "learning_element_id", "visit_start", "visit_end"],
+                    201,
             ),
             # Wrong data format
             ({"visit_start_time": "01.01.2023"}, 4, ["error", "message"], 400),
@@ -1061,18 +1062,18 @@ class TestApi:
         ],
     )
     def test_post_learning_element_visit(
-        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global student_id, learning_element_id
         url = (
-            path_lms_student
-            + "/"
-            + str(student_id)
-            + "/"
-            + str(moodle_user_id)
-            + path_learning_element
-            + "/"
-            + str(learning_element_id)
+                path_lms_student
+                + "/"
+                + str(student_id)
+                + "/"
+                + str(moodle_user_id)
+                + path_learning_element
+                + "/"
+                + str(learning_element_id)
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1087,95 +1088,43 @@ class TestApi:
         [
             # Working Example ACO
             (
-                {"algorithm": "aco"},
-                4,
-                [
-                    "id",
-                    "course_id",
-                    "topic_id",
-                    "student_id",
-                    "based_on",
-                    "path",
-                    "calculated_on",
-                ],
-                201,
+                    {"algorithm": "aco"},
+                    4,
+                    [
+                        "id",
+                        "course_id",
+                        "topic_id",
+                        "student_id",
+                        "based_on",
+                        "path",
+                        "calculated_on",
+                    ],
+                    201,
             ),
             # Working Example Graf
             (
-                {"algorithm": "graf"},
-                4,
-                [
-                    "id",
-                    "course_id",
-                    "topic_id",
-                    "student_id",
-                    "based_on",
-                    "path",
-                    "calculated_on",
-                ],
-                201,
+                    {"algorithm": "graf"},
+                    4,
+                    [
+                        "id",
+                        "course_id",
+                        "topic_id",
+                        "student_id",
+                        "based_on",
+                        "path",
+                        "calculated_on",
+                    ],
+                    201,
             ),
             # Missing Parameter
             ({}, 4, ["error", "message"], 400),
         ],
     )
     def test_post_learning_path(
-        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(moodle_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_course
-            + "/"
-            + str(course_id)
-            + path_topic
-            + "/"
-            + str(sub_topic_id)
-            + path_learning_path
-        )
-        r = client_class.post(url, json=input)
-        assert r.status_code == status_code_expected
-        response = json.loads(r.data.decode("utf-8").strip("\n"))
-        for key in keys_expected:
-            assert key in response.keys()
-
-    # Learning Path is calculated for ga
-    @pytest.mark.parametrize(
-        "input, moodle_user_id, keys_exp,\
-                            status_code_exp",
-        [
-            # Working Example
-            (
-                {"algorithm": "ga"},
-                4,
-                [
-                    "id",
-                    "course_id",
-                    "topic_id",
-                    "student_id",
-                    "based_on",
-                    "path",
-                    "calculated_on",
-                ],
-                201,
-            ),
-            # Missing Parameter
-            ({}, 4, ["error", "message"], 400),
-        ],
-    )
-    def test_post_learning_path_ga(
-        self, client_class, input, moodle_user_id, keys_exp, status_code_exp
-    ):
-        global user_id_student, student_id, course_id2, sub_topic_id2
-        client_post = client_class.post(
-            (
                 path_user
                 + "/"
                 + str(user_id_student)
@@ -1191,6 +1140,58 @@ class TestApi:
                 + "/"
                 + str(sub_topic_id)
                 + path_learning_path
+        )
+        r = client_class.post(url, json=input)
+        assert r.status_code == status_code_expected
+        response = json.loads(r.data.decode("utf-8").strip("\n"))
+        for key in keys_expected:
+            assert key in response.keys()
+
+    # Learning Path is calculated for ga
+    @pytest.mark.parametrize(
+        "input, moodle_user_id, keys_exp,\
+                            status_code_exp",
+        [
+            # Working Example
+            (
+                    {"algorithm": "ga"},
+                    4,
+                    [
+                        "id",
+                        "course_id",
+                        "topic_id",
+                        "student_id",
+                        "based_on",
+                        "path",
+                        "calculated_on",
+                    ],
+                    201,
+            ),
+            # Missing Parameter
+            ({}, 4, ["error", "message"], 400),
+        ],
+    )
+    def test_post_learning_path_ga(
+            self, client_class, input, moodle_user_id, keys_exp, status_code_exp
+    ):
+        global user_id_student, student_id, course_id2, sub_topic_id2
+        client_post = client_class.post(
+            (
+                    path_user
+                    + "/"
+                    + str(user_id_student)
+                    + "/"
+                    + str(moodle_user_id)
+                    + path_student
+                    + "/"
+                    + str(student_id)
+                    + path_course
+                    + "/"
+                    + str(course_id)
+                    + path_topic
+                    + "/"
+                    + str(sub_topic_id)
+                    + path_learning_path
             ),
             json=input,
         )
@@ -1206,36 +1207,36 @@ class TestApi:
         [
             # Working Example
             (
-                {
-                    "report_topic": "Lernelement",
-                    "report_type": "Funktionalität",
-                    "report_description": "Test",
-                },
-                4,
-                [
-                    "id",
-                    "user_id",
-                    "report_topic",
-                    "report_type",
-                    "report_description",
-                ],
-                201,
+                    {
+                        "report_topic": "Lernelement",
+                        "report_type": "Funktionalität",
+                        "report_description": "Test",
+                    },
+                    4,
+                    [
+                        "id",
+                        "user_id",
+                        "report_topic",
+                        "report_type",
+                        "report_description",
+                    ],
+                    201,
             ),
             # Missing Parameter
             ({}, 4, ["error", "message"], 400),
         ],
     )
     def test_post_contact_form(
-        self, client_class, input, lms_user_id, keys_expected, status_code_expected
+            self, client_class, input, lms_user_id, keys_expected, status_code_expected
     ):
         user_id_student = 4
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_contactform
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_contactform
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1249,79 +1250,79 @@ class TestApi:
         [
             # Working Example
             (
-                {
-                    "name": "FCP",
-                    "value": 3957.6999999284744,
-                    "rating": "poor",
-                    "delta": 3957.6999999284744,
-                    "entries": [
-                        {
-                            "name": "first-contentful-paint",
-                            "entryType": "paint",
-                            "startTime": 3957.6999999284744,
-                            "duration": 0,
-                        },
-                        {
-                            "name": "http://localhost:8080/",
-                            "entryType": "navigation",
-                            "startTime": 0,
-                            "duration": 4003.0999999046326,
-                            "initiatorType": "navigation",
-                            "nextHopProtocol": "http/1.1",
-                            "workerStart": 0,
-                            "redirectStart": 0,
-                            "redirectEnd": 0,
-                            "fetchStart": 7.699999928474426,
-                            "domainLookupStart": 99.19999992847443,
-                            "domainLookupEnd": 99.29999995231628,
-                            "connectStart": 99.29999995231628,
-                            "connectEnd": 99.89999997615814,
-                            "secureConnectionStart": "0,",
-                            "requestStart": 100,
-                            "responseStart": 3638.7999999523163,
-                            "responseEnd": 3640,
-                            "transferSize": 810,
-                            "encodedBodySize": 510,
-                            "decodedBodySize": 510,
-                            "serverTiming": [""],
-                            "workerTiming": [""],
-                            "unloadEventStart": 0,
-                            "unloadEventEnd": 0,
-                            "domInteractive": 3717.5,
-                            "domContentLoadedEventStart": 3937.5999999046326,
-                            "domContentLoadedEventEnd": 3938.899999976158,
-                            "domComplete": 4003.0999999046326,
-                            "loadEventStart": 4003.0999999046326,
-                            "loadEventEnd": 4003.0999999046326,
-                            "type": "navigate",
-                            "redirectCount": 0,
-                        },
-                        {},
-                        {
-                            "name": "",
-                            "entryType": "largest-contentful-paint",
-                            "startTime": 3957.699,
-                            "duration": 0,
-                            "size": 867,
-                            "renderTime": 3957.699,
-                            "loadTime": 0,
-                            "firstAnimatedFrameTime": 0,
-                            "id": "",
-                            "url": "",
-                        },
-                        {},
-                        {},
-                    ],
-                    "id": "v3-1665068191217-4248786867866",
-                    "navigationType": "navigate",
-                },
-                ["name", "value", "rating", "delta", "entries", "id", "navigationType"],
-                201,
+                    {
+                        "name": "FCP",
+                        "value": 3957.6999999284744,
+                        "rating": "poor",
+                        "delta": 3957.6999999284744,
+                        "entries": [
+                            {
+                                "name": "first-contentful-paint",
+                                "entryType": "paint",
+                                "startTime": 3957.6999999284744,
+                                "duration": 0,
+                            },
+                            {
+                                "name": "http://localhost:8080/",
+                                "entryType": "navigation",
+                                "startTime": 0,
+                                "duration": 4003.0999999046326,
+                                "initiatorType": "navigation",
+                                "nextHopProtocol": "http/1.1",
+                                "workerStart": 0,
+                                "redirectStart": 0,
+                                "redirectEnd": 0,
+                                "fetchStart": 7.699999928474426,
+                                "domainLookupStart": 99.19999992847443,
+                                "domainLookupEnd": 99.29999995231628,
+                                "connectStart": 99.29999995231628,
+                                "connectEnd": 99.89999997615814,
+                                "secureConnectionStart": "0,",
+                                "requestStart": 100,
+                                "responseStart": 3638.7999999523163,
+                                "responseEnd": 3640,
+                                "transferSize": 810,
+                                "encodedBodySize": 510,
+                                "decodedBodySize": 510,
+                                "serverTiming": [""],
+                                "workerTiming": [""],
+                                "unloadEventStart": 0,
+                                "unloadEventEnd": 0,
+                                "domInteractive": 3717.5,
+                                "domContentLoadedEventStart": 3937.5999999046326,
+                                "domContentLoadedEventEnd": 3938.899999976158,
+                                "domComplete": 4003.0999999046326,
+                                "loadEventStart": 4003.0999999046326,
+                                "loadEventEnd": 4003.0999999046326,
+                                "type": "navigate",
+                                "redirectCount": 0,
+                            },
+                            {},
+                            {
+                                "name": "",
+                                "entryType": "largest-contentful-paint",
+                                "startTime": 3957.699,
+                                "duration": 0,
+                                "size": 867,
+                                "renderTime": 3957.699,
+                                "loadTime": 0,
+                                "firstAnimatedFrameTime": 0,
+                                "id": "",
+                                "url": "",
+                            },
+                            {},
+                            {},
+                        ],
+                        "id": "v3-1665068191217-4248786867866",
+                        "navigationType": "navigate",
+                    },
+                    ["name", "value", "rating", "delta", "entries", "id", "navigationType"],
+                    201,
             )
         ],
     )
     def test_api_post_frontend_logs(
-        self, client_class, input, keys_expected, status_code_expected
+            self, client_class, input, keys_expected, status_code_expected
     ):
         url = path_frontend_logs
         r = client_class.post(url, json=input)
@@ -1338,22 +1339,22 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                [
-                    "learning_style",
-                    "learning_strategy",
-                    "learning_analytics",
-                    "knowledge",
-                ],
-                False,
+                    4,
+                    200,
+                    [
+                        "learning_style",
+                        "learning_strategy",
+                        "learning_analytics",
+                        "knowledge",
+                    ],
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True),
         ],
     )
     def test_get_students_learning_characteristics(
-        self, client_class, lms_user_id, status_code_expected, keys_expected, error
+            self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1361,15 +1362,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_learning_characteristics
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_learning_characteristics
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1389,7 +1390,7 @@ class TestApi:
         ],
     )
     def test_get_students_learning_analytics(
-        self, client_class, lms_user_id, status_code_expected, keys_expected, error
+            self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1397,15 +1398,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_learning_analytics
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_learning_analytics
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1420,26 +1421,26 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                [
-                    "perception_dimension",
-                    "perception_value",
-                    "input_dimension",
-                    "input_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                False,
+                    4,
+                    200,
+                    [
+                        "perception_dimension",
+                        "perception_value",
+                        "input_dimension",
+                        "input_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True),
         ],
     )
     def test_get_students_learning_style(
-        self, client_class, lms_user_id, status_code_expected, keys_expected, error
+            self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1447,15 +1448,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_learning_style
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_learning_style
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1475,7 +1476,7 @@ class TestApi:
         ],
     )
     def test_get_students_learning_strategy(
-        self, client_class, lms_user_id, status_code_expected, keys_expected, error
+            self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1483,15 +1484,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_learning_strategy
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_learning_strategy
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1511,7 +1512,7 @@ class TestApi:
         ],
     )
     def test_get_students_knowledge(
-        self, client_class, lms_user_id, status_code_expected, keys_expected, error
+            self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1519,15 +1520,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_knowledge
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_knowledge
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1547,13 +1548,13 @@ class TestApi:
         ],
     )
     def test_get_student_courses(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected_1,
-        keys_expected_2,
-        error,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected_1,
+            keys_expected_2,
+            error,
     ):
         global user_id_student, student_id
         if error:
@@ -1561,15 +1562,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1598,13 +1599,13 @@ class TestApi:
         ],
     )
     def test_get_student_course(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected,
-        error_student,
-        error_course,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected,
+            error_student,
+            error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1616,17 +1617,17 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1642,21 +1643,21 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                ["topics"],
-                [
-                    "id",
-                    "lms_id",
-                    "name",
-                    "is_topic",
-                    "contains_le",
-                    "university",
-                    "parent_id",
-                    "student_topic",
-                ],
-                False,
-                False,
+                    4,
+                    200,
+                    ["topics"],
+                    [
+                        "id",
+                        "lms_id",
+                        "name",
+                        "is_topic",
+                        "contains_le",
+                        "university",
+                        "parent_id",
+                        "student_topic",
+                    ],
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False),
@@ -1665,14 +1666,14 @@ class TestApi:
         ],
     )
     def test_get_student_course_topics(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected_1,
-        keys_expected_2,
-        error_student,
-        error_course,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected_1,
+            keys_expected_2,
+            error_student,
+            error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1684,18 +1685,18 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1717,20 +1718,20 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                ["learning_elements"],
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "university",
-                    "student_learning_element",
-                ],
-                False,
-                False,
+                    4,
+                    200,
+                    ["learning_elements"],
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "university",
+                        "student_learning_element",
+                    ],
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False),
@@ -1739,14 +1740,14 @@ class TestApi:
         ],
     )
     def test_get_les_in_course_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected_1,
-        keys_expected_2,
-        error_student,
-        error_course,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected_1,
+            keys_expected_2,
+            error_student,
+            error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1758,18 +1759,18 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_learning_element
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_learning_element
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1791,21 +1792,21 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                [
-                    "id",
-                    "lms_id",
-                    "name",
-                    "is_topic",
-                    "contains_le",
-                    "university",
-                    "parent_id",
-                    "student_topic",
-                ],
-                False,
-                False,
-                False,
+                    4,
+                    200,
+                    [
+                        "id",
+                        "lms_id",
+                        "name",
+                        "is_topic",
+                        "contains_le",
+                        "university",
+                        "parent_id",
+                        "student_topic",
+                    ],
+                    False,
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False),
@@ -1816,14 +1817,14 @@ class TestApi:
         ],
     )
     def test_get_topic_by_id_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected,
-        error_student,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected,
+            error_student,
+            error_course,
+            error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -1839,20 +1840,20 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1868,20 +1869,20 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "university",
-                    "student_learning_element",
-                ],
-                200,
-                False,
-                False,
-                False,
+                    4,
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "university",
+                        "student_learning_element",
+                    ],
+                    200,
+                    False,
+                    False,
+                    False,
             ),
             # User not found
             (1, ["error", "message"], 404, True, False, False),
@@ -1892,14 +1893,14 @@ class TestApi:
         ],
     )
     def test_get_topic_recommendation_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        keys_expected,
-        status_code_expected,
-        error_student,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            lms_user_id,
+            keys_expected,
+            status_code_expected,
+            error_student,
+            error_course,
+            error_topic,
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         if error_student:
@@ -1915,21 +1916,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + path_recommendation
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + path_recommendation
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1945,20 +1946,20 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                [
-                    "id",
-                    "course_id",
-                    "topic_id",
-                    "student_id",
-                    "based_on",
-                    "calculated_on",
-                    "path",
-                ],
-                False,
-                False,
-                False,
+                    4,
+                    200,
+                    [
+                        "id",
+                        "course_id",
+                        "topic_id",
+                        "student_id",
+                        "based_on",
+                        "calculated_on",
+                        "path",
+                    ],
+                    False,
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False),
@@ -1969,14 +1970,14 @@ class TestApi:
         ],
     )
     def test_get_learning_path_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected,
-        error_student,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected,
+            error_student,
+            error_course,
+            error_topic,
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         if error_student:
@@ -1992,21 +1993,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + path_learning_path
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + path_learning_path
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2022,22 +2023,22 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                ["topics"],
-                [
-                    "id",
-                    "lms_id",
-                    "name",
-                    "is_topic",
-                    "contains_le",
-                    "university",
-                    "parent_id",
-                    "student_topic",
-                ],
-                False,
-                False,
-                False,
+                    4,
+                    200,
+                    ["topics"],
+                    [
+                        "id",
+                        "lms_id",
+                        "name",
+                        "is_topic",
+                        "contains_le",
+                        "university",
+                        "parent_id",
+                        "student_topic",
+                    ],
+                    False,
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False, False),
@@ -2048,15 +2049,15 @@ class TestApi:
         ],
     )
     def test_get_sub_topics_for_topic(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected_1,
-        keys_expected_2,
-        error_student,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected_1,
+            keys_expected_2,
+            error_student,
+            error_course,
+            error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -2072,21 +2073,21 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + path_subtopic
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + path_subtopic
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2109,21 +2110,21 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                ["learning_elements"],
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "university",
-                    "student_learning_element",
-                ],
-                False,
-                False,
-                False,
+                    4,
+                    200,
+                    ["learning_elements"],
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "university",
+                        "student_learning_element",
+                    ],
+                    False,
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False, False),
@@ -2134,15 +2135,15 @@ class TestApi:
         ],
     )
     def test_get_les_for_topic_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected_1,
-        keys_expected_2,
-        error_student,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected_1,
+            keys_expected_2,
+            error_student,
+            error_course,
+            error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -2158,21 +2159,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + path_learning_element
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + path_learning_element
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2195,21 +2196,21 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                200,
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "university",
-                    "student_learning_element",
-                ],
-                False,
-                False,
-                False,
-                False,
+                    4,
+                    200,
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "university",
+                        "student_learning_element",
+                    ],
+                    False,
+                    False,
+                    False,
+                    False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False, False),
@@ -2222,15 +2223,15 @@ class TestApi:
         ],
     )
     def test_get_le_by_id_for_student(
-        self,
-        client_class,
-        lms_user_id,
-        status_code_expected,
-        keys_expected,
-        error_student,
-        error_course,
-        error_topic,
-        error_le,
+            self,
+            client_class,
+            lms_user_id,
+            status_code_expected,
+            keys_expected,
+            error_student,
+            error_course,
+            error_topic,
+            error_le,
     ):
         global user_id_student, student_id, course_id
         global topic_id, learning_element_id
@@ -2251,23 +2252,23 @@ class TestApi:
         else:
             learning_element_id_use = learning_element_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_course
-            + "/"
-            + str(course_id_use)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + path_learning_element
-            + "/"
-            + str(learning_element_id_use)
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_course
+                + "/"
+                + str(course_id_use)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + path_learning_element
+                + "/"
+                + str(learning_element_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2288,13 +2289,13 @@ class TestApi:
         ],
     )
     def test_get_users_by_admin_id(
-        self,
-        client_class,
-        lms_user_id,
-        keys_expected_1,
-        keys_expected_2,
-        status_code_expected,
-        error_user,
+            self,
+            client_class,
+            lms_user_id,
+            keys_expected_1,
+            keys_expected_2,
+            status_code_expected,
+            error_user,
     ):
         global user_id_admin, admin_id
         if error_user:
@@ -2302,15 +2303,15 @@ class TestApi:
         else:
             user_id_use = user_id_admin
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_admin
-            + "/"
-            + str(admin_id)
-            + path_user
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_admin
+                + "/"
+                + str(admin_id)
+                + path_user
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2334,12 +2335,12 @@ class TestApi:
         ],
     )
     def test_get_logs_by_admin_id(
-        self,
-        client_class,
-        lms_user_id,
-        keys_expected,
-        status_code_expected,
-        error_admin,
+            self,
+            client_class,
+            lms_user_id,
+            keys_expected,
+            status_code_expected,
+            error_admin,
     ):
         global user_id_admin, admin_id
         if error_admin:
@@ -2347,15 +2348,15 @@ class TestApi:
         else:
             user_id_use = user_id_admin
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_admin
-            + "/"
-            + str(admin_id)
-            + path_logs
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_admin
+                + "/"
+                + str(admin_id)
+                + path_logs
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2376,13 +2377,13 @@ class TestApi:
         ],
     )
     def test_get_courses_by_teacher_id(
-        self,
-        client_class,
-        lms_user_id,
-        keys_expected_1,
-        keys_expected_2,
-        status_code_expected,
-        error_teacher,
+            self,
+            client_class,
+            lms_user_id,
+            keys_expected_1,
+            keys_expected_2,
+            status_code_expected,
+            error_teacher,
     ):
         global user_id_teacher, teacher_id
         if error_teacher:
@@ -2390,15 +2391,15 @@ class TestApi:
         else:
             user_id_use = user_id_teacher
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_teacher
-            + "/"
-            + str(teacher_id)
-            + path_course
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_teacher
+                + "/"
+                + str(teacher_id)
+                + path_course
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2417,17 +2418,17 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                ["id", "name", "university", "lms_user_id", "role", "settings"],
-                200,
-                False,
+                    4,
+                    ["id", "name", "university", "lms_user_id", "role", "settings"],
+                    200,
+                    False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_get_user_by_id(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -2453,7 +2454,7 @@ class TestApi:
         ],
     )
     def test_get_user_settings_by_id(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -2461,7 +2462,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2480,32 +2481,32 @@ class TestApi:
             (4, {"theme": "dark", "pswd": "password"}, ["theme", "pswd"], 201, False),
             # User not found
             (
-                1,
-                {
-                    "theme": [
-                        {
-                            "color": "dark",
-                            "style": "dark",
-                            "typography": "Comic Sans",
-                            "language": "EN",
-                        }
-                    ],
-                    "password": "password",
-                },
-                ["error", "message"],
-                404,
-                True,
+                    1,
+                    {
+                        "theme": [
+                            {
+                                "color": "dark",
+                                "style": "dark",
+                                "typography": "Comic Sans",
+                                "language": "EN",
+                            }
+                        ],
+                        "password": "password",
+                    },
+                    ["error", "message"],
+                    404,
+                    True,
             ),
         ],
     )
     def test_update_user_settings_by_id(
-        self,
-        client_class,
-        lms_user_id,
-        request_body,
-        keys_expected,
-        status_code_expected,
-        error,
+            self,
+            client_class,
+            lms_user_id,
+            request_body,
+            keys_expected,
+            status_code_expected,
+            error,
     ):
         global user_id_student
         if error:
@@ -2513,7 +2514,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.put(url, json=request_body)
         assert r.status_code == status_code_expected
@@ -2528,91 +2529,91 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                {
-                    "perception_dimension": "SNS",
-                    "perception_value": 7,
-                    "input_dimension": "VIS",
-                    "input_value": 7,
-                    "processing_dimension": "ACT",
-                    "processing_value": 7,
-                    "understanding_dimension": "GLO",
-                    "understanding_value": 7,
-                },
-                [
-                    "perception_dimension",
-                    "perception_value",
-                    "input_dimension",
-                    "input_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                201,
-                False,
+                    4,
+                    {
+                        "perception_dimension": "SNS",
+                        "perception_value": 7,
+                        "input_dimension": "VIS",
+                        "input_value": 7,
+                        "processing_dimension": "ACT",
+                        "processing_value": 7,
+                        "understanding_dimension": "GLO",
+                        "understanding_value": 7,
+                    },
+                    [
+                        "perception_dimension",
+                        "perception_value",
+                        "input_dimension",
+                        "input_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    201,
+                    False,
             ),
             # User not found
             (
-                1,
-                {
-                    "perception_dimension": "SNS",
-                    "perception_value": 7,
-                    "input_dimension": "VIS",
-                    "input_value": 7,
-                    "processing_dimension": "ACT",
-                    "processing_value": 7,
-                    "understanding_dimension": "GLO",
-                    "understanding_value": 7,
-                },
-                ["error", "message"],
-                404,
-                True,
+                    1,
+                    {
+                        "perception_dimension": "SNS",
+                        "perception_value": 7,
+                        "input_dimension": "VIS",
+                        "input_value": 7,
+                        "processing_dimension": "ACT",
+                        "processing_value": 7,
+                        "understanding_dimension": "GLO",
+                        "understanding_value": 7,
+                    },
+                    ["error", "message"],
+                    404,
+                    True,
             ),
             # Empty Request body
             (4, {}, ["error", "message"], 400, False),
             # Wrong numbers in request body
             (
-                4,
-                {
-                    "perception_dimension": "SNS",
-                    "perception_value": 12,
-                    "input_dimension": "VIS",
-                    "input_value": 7,
-                    "processing_dimension": "ACT",
-                    "processing_value": 7,
-                    "understanding_dimension": "GLO",
-                    "understanding_value": 7,
-                },
-                ["error", "message"],
-                400,
-                False,
+                    4,
+                    {
+                        "perception_dimension": "SNS",
+                        "perception_value": 12,
+                        "input_dimension": "VIS",
+                        "input_value": 7,
+                        "processing_dimension": "ACT",
+                        "processing_value": 7,
+                        "understanding_dimension": "GLO",
+                        "understanding_value": 7,
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Wrong number of dimensions in request body
             (
-                4,
-                {
-                    "perception_dimension": "SNS",
-                    "perception_value": 7,
-                    "input_dimension": "VIS",
-                    "input_value": 7,
-                    "processing_dimension": "ACT",
-                    "processing_value": 7,
-                },
-                ["error", "message"],
-                400,
-                False,
+                    4,
+                    {
+                        "perception_dimension": "SNS",
+                        "perception_value": 7,
+                        "input_dimension": "VIS",
+                        "input_value": 7,
+                        "processing_dimension": "ACT",
+                        "processing_value": 7,
+                    },
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_update_learning_style_by_student_id(
-        self,
-        client_class,
-        lms_user_id,
-        request_body,
-        keys_expected,
-        status_code_expected,
-        error,
+            self,
+            client_class,
+            lms_user_id,
+            request_body,
+            keys_expected,
+            status_code_expected,
+            error,
     ):
         global user_id_student, student_id
         if error:
@@ -2620,15 +2621,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_learning_style
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + path_learning_style
         )
         r = client_class.put(url, json=request_body)
         assert r.status_code == status_code_expected
@@ -2643,55 +2644,55 @@ class TestApi:
         [
             # Working Example
             (
-                {
-                    "name": "Max Mustermann",
-                    "role": "Student",
-                    "university": "TH-AB",
-                    "settings": [
-                        {
-                            "theme": [
-                                {
-                                    "color": "dark",
-                                    "style": "dark",
-                                    "typography": "Arial Black",
-                                    "language": "DE",
-                                }
-                            ],
-                            "password": "password",
-                        }
-                    ],
-                },
-                4,
-                ["id", "name", "university", "lms_user_id", "role", "settings"],
-                201,
+                    {
+                        "name": "Max Mustermann",
+                        "role": "Student",
+                        "university": "TH-AB",
+                        "settings": [
+                            {
+                                "theme": [
+                                    {
+                                        "color": "dark",
+                                        "style": "dark",
+                                        "typography": "Arial Black",
+                                        "language": "DE",
+                                    }
+                                ],
+                                "password": "password",
+                            }
+                        ],
+                    },
+                    4,
+                    ["id", "name", "university", "lms_user_id", "role", "settings"],
+                    201,
             ),
             # Missing Parameter
             (
-                {
-                    "role": "Student",
-                    "university": "TH-AB",
-                    "settings": [
-                        {
-                            "theme": [
-                                {
-                                    "color": "dark",
-                                    "style": "dark",
-                                    "typography": "Arial Black",
-                                    "language": "DE",
-                                }
-                            ],
-                            "password": "password",
-                        }
-                    ],
-                },
-                4,
-                ["error", "message"],
-                400,
+                    {
+                        "role": "Student",
+                        "university": "TH-AB",
+                        "settings": [
+                            {
+                                "theme": [
+                                    {
+                                        "color": "dark",
+                                        "style": "dark",
+                                        "typography": "Arial Black",
+                                        "language": "DE",
+                                    }
+                                ],
+                                "password": "password",
+                            }
+                        ],
+                    },
+                    4,
+                    ["error", "message"],
+                    400,
             ),
         ],
     )
     def test_update_user_from_moodle(
-        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global user_id_student
         url = path_lms_user + "/" + str(user_id_student) + "/" + str(moodle_user_id)
@@ -2708,46 +2709,46 @@ class TestApi:
         [
             # Working Example
             (
-                {
-                    "name": "Test Course Updated",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                ["id", "name", "lms_id", "created_at", "created_by", "university"],
-                201,
+                    {
+                        "name": "Test Course Updated",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["id", "name", "lms_id", "created_at", "created_by", "university"],
+                    201,
             ),
             # Missing Parameter
             (
-                {
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                ["error", "message"],
-                400,
+                    {
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["error", "message"],
+                    400,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "name": "Test Course Updated",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "01.01.2023",
-                    "university": "TH-AB",
-                },
-                1,
-                ["error", "message"],
-                400,
+                    {
+                        "name": "Test Course Updated",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "01.01.2023",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    ["error", "message"],
+                    400,
             ),
         ],
     )
     def test_update_course_from_moodle(
-        self, client_class, input, moodle_course_id, keys_expected, status_code_expected
+            self, client_class, input, moodle_course_id, keys_expected, status_code_expected
     ):
         global course_id
         url = path_lms_course + "/" + str(course_id) + "/" + str(moodle_course_id)
@@ -2764,106 +2765,106 @@ class TestApi:
         [
             # Working Example for Topic
             (
-                {
-                    "name": "Test Topic Updated",
-                    "is_topic": True,
-                    "parent_id": None,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                [
-                    "id",
-                    "name",
-                    "lms_id",
-                    "is_topic",
-                    "parent_id",
-                    "contains_le",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
-                False,
+                    {
+                        "name": "Test Topic Updated",
+                        "is_topic": True,
+                        "parent_id": None,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    [
+                        "id",
+                        "name",
+                        "lms_id",
+                        "is_topic",
+                        "parent_id",
+                        "contains_le",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
+                    False,
             ),
             # Working Example for Sub-Topic
             (
-                {
-                    "name": "Test Sub-Topic Updated",
-                    "is_topic": False,
-                    "parent_id": None,
-                    "contains_le": True,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                [
-                    "id",
-                    "name",
-                    "lms_id",
-                    "is_topic",
-                    "parent_id",
-                    "contains_le",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
-                True,
+                    {
+                        "name": "Test Sub-Topic Updated",
+                        "is_topic": False,
+                        "parent_id": None,
+                        "contains_le": True,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    [
+                        "id",
+                        "name",
+                        "lms_id",
+                        "is_topic",
+                        "parent_id",
+                        "contains_le",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
+                    True,
             ),
             # Missing Parameter
             (
-                {
-                    "is_topic": True,
-                    "parent_id": 1,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "is_topic": True,
+                        "parent_id": 1,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "name": "Test Topic Updated",
-                    "is_topic": True,
-                    "parent_id": None,
-                    "contains_le": False,
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "01-01-2023",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                ["error", "message"],
-                400,
-                False,
+                    {
+                        "name": "Test Topic Updated",
+                        "is_topic": True,
+                        "parent_id": None,
+                        "contains_le": False,
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "01-01-2023",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
+                    False,
             ),
         ],
     )
     def test_update_topic_from_moodle(
-        self,
-        client_class,
-        input,
-        moodle_course_id,
-        moodle_topic_id,
-        keys_expected,
-        status_code_expected,
-        sub_topic,
+            self,
+            client_class,
+            input,
+            moodle_course_id,
+            moodle_topic_id,
+            keys_expected,
+            status_code_expected,
+            sub_topic,
     ):
         global course_id, topic_id, sub_topic_id
         if sub_topic:
@@ -2872,16 +2873,16 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + "/"
-            + str(moodle_topic_id)
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + "/"
+                + str(moodle_topic_id)
         )
         r = client_class.put(url, json=input)
         assert r.status_code == status_code_expected
@@ -2897,98 +2898,125 @@ class TestApi:
         [
             # Working Example for LE
             (
-                {
-                    "activity_type": "Quiz",
-                    "classification": "RQ",
-                    "name": "Test Learning Element Updated",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                1,
-                [
-                    "id",
-                    "lms_id",
-                    "activity_type",
-                    "classification",
-                    "name",
-                    "created_by",
-                    "created_at",
-                    "university",
-                ],
-                201,
+                    {
+                        "activity_type": "Quiz",
+                        "classification": "RQ",
+                        "name": "Test Learning Element Updated",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    1,
+                    [
+                        "id",
+                        "lms_id",
+                        "activity_type",
+                        "classification",
+                        "name",
+                        "created_by",
+                        "created_at",
+                        "university",
+                    ],
+                    201,
             ),
             # Missing Parameter
             (
-                {
-                    "classification": "RQ",
-                    "name": "Test Learning Element Updated",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "2018-07-21T17:32:28Z",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                1,
-                ["error", "message"],
-                400,
+                    {
+                        "classification": "RQ",
+                        "name": "Test Learning Element Updated",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "2018-07-21T17:32:28Z",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
             ),
             # Parameter with wrong data type
             (
-                {
-                    "activity_type": "Quiz",
-                    "classification": "RQ",
-                    "name": "Test Learning Element Updated",
-                    "created_by": "Maria Musterfrau",
-                    "created_at": "2023-08-01T13:37:42Z",
-                    "last_updated": "01.01.2023",
-                    "university": "TH-AB",
-                },
-                1,
-                1,
-                1,
-                ["error", "message"],
-                400,
+                    {
+                        "activity_type": "Quiz",
+                        "classification": "RQ",
+                        "name": "Test Learning Element Updated",
+                        "created_by": "Maria Musterfrau",
+                        "created_at": "2023-08-01T13:37:42Z",
+                        "last_updated": "01.01.2023",
+                        "university": "TH-AB",
+                    },
+                    1,
+                    1,
+                    1,
+                    ["error", "message"],
+                    400,
             ),
         ],
     )
     def test_update_le_from_moodle(
-        self,
-        client_class,
-        input,
-        moodle_course_id,
-        moodle_topic_id,
-        moodle_learning_element_id,
-        keys_expected,
-        status_code_expected,
+            self,
+            client_class,
+            input,
+            moodle_course_id,
+            moodle_topic_id,
+            moodle_learning_element_id,
+            keys_expected,
+            status_code_expected,
     ):
         global course_id, sub_topic_id, learning_element_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
-            + "/"
-            + str(sub_topic_id)
-            + "/"
-            + str(moodle_topic_id)
-            + path_learning_element
-            + "/"
-            + str(learning_element_id)
-            + "/"
-            + str(moodle_learning_element_id)
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
+                + "/"
+                + str(sub_topic_id)
+                + "/"
+                + str(moodle_topic_id)
+                + path_learning_element
+                + "/"
+                + str(learning_element_id)
+                + "/"
+                + str(moodle_learning_element_id)
         )
         r = client_class.put(url, json=input)
         assert r.status_code == status_code_expected
         response = json.loads(r.data.decode("utf-8").strip("\n"))
         for key in keys_expected:
             assert key in response.keys()
+
+    # Get all learning element statuses for a student for a course
+    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @pytest.mark.parametrize(
+        "course_id, student_id",
+        [
+            # Working Example
+            (1, 1)
+        ],
+    )
+    def test_get_activity_status_for_student(
+            self, client_class, course_id, student_id
+    ):
+        global user_id_student
+        url = (
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + "/"
+                + path_activity_status
+        )
+        r = client_class.get(url)
+        #response = json.loads(r.data.decode("utf-8").strip("\n"))
+        #assert "activity_status" in response.keys()
 
     # DELETE METHODS
     # Reset User Settings
@@ -3003,7 +3031,7 @@ class TestApi:
         ],
     )
     def test_reset_user_settings(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -3011,7 +3039,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3026,24 +3054,24 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                [
-                    "id",
-                    "knowledge",
-                    "learning_analytics",
-                    "learning_strategy",
-                    "learning_style",
-                    "student_id",
-                ],
-                200,
-                False,
+                    4,
+                    [
+                        "id",
+                        "knowledge",
+                        "learning_analytics",
+                        "learning_strategy",
+                        "learning_style",
+                        "student_id",
+                    ],
+                    200,
+                    False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_characteristics(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3051,15 +3079,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_learning_characteristics
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + path_learning_characteristics
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3079,7 +3107,7 @@ class TestApi:
         ],
     )
     def test_reset_learning_analytics(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3087,15 +3115,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_learning_analytics
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + path_learning_analytics
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3110,28 +3138,28 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                [
-                    "id",
-                    "characteristic_id",
-                    "perception_dimension",
-                    "perception_value",
-                    "input_dimension",
-                    "input_value",
-                    "processing_dimension",
-                    "processing_value",
-                    "understanding_dimension",
-                    "understanding_value",
-                ],
-                200,
-                False,
+                    4,
+                    [
+                        "id",
+                        "characteristic_id",
+                        "perception_dimension",
+                        "perception_value",
+                        "input_dimension",
+                        "input_value",
+                        "processing_dimension",
+                        "processing_value",
+                        "understanding_dimension",
+                        "understanding_value",
+                    ],
+                    200,
+                    False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_style(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3139,15 +3167,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_learning_style
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + path_learning_style
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3162,37 +3190,37 @@ class TestApi:
         [
             # Working Example
             (
-                4,
-                [
-                    "att",
-                    "characteristic_id",
-                    "cogn_str",
-                    "con",
-                    "crit_rev",
-                    "eff",
-                    "elab",
-                    "ext_res_mng_str",
-                    "goal_plan",
-                    "id",
-                    "int_res_mng_str",
-                    "lit_res",
-                    "lrn_env",
-                    "lrn_w_cls",
-                    "metacogn_str",
-                    "org",
-                    "reg",
-                    "rep",
-                    "time",
-                ],
-                200,
-                False,
+                    4,
+                    [
+                        "att",
+                        "characteristic_id",
+                        "cogn_str",
+                        "con",
+                        "crit_rev",
+                        "eff",
+                        "elab",
+                        "ext_res_mng_str",
+                        "goal_plan",
+                        "id",
+                        "int_res_mng_str",
+                        "lit_res",
+                        "lrn_env",
+                        "lrn_w_cls",
+                        "metacogn_str",
+                        "org",
+                        "reg",
+                        "rep",
+                        "time",
+                    ],
+                    200,
+                    False,
             ),
             # User not found
             (100, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_strategy(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3202,15 +3230,15 @@ class TestApi:
             user_id_use = user_id_student
             student_id_use = student_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id_use)
-            + path_learning_strategy
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id_use)
+                + path_learning_strategy
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3230,7 +3258,7 @@ class TestApi:
         ],
     )
     def test_reset_knowledge(
-        self, client_class, lms_user_id, keys_expected, status_code_expected, error
+            self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3238,15 +3266,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-            path_user
-            + "/"
-            + str(user_id_use)
-            + "/"
-            + str(lms_user_id)
-            + path_student
-            + "/"
-            + str(student_id)
-            + path_knowledge
+                path_user
+                + "/"
+                + str(user_id_use)
+                + "/"
+                + str(lms_user_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + path_knowledge
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3264,16 +3292,16 @@ class TestApi:
         ],
     )
     def test_delete_contact_form(
-        self, client_class, lms_user_id, user_id, status_code_expected
+            self, client_class, lms_user_id, user_id, status_code_expected
     ):
         user_id_student = user_id
         url = (
-            path_user
-            + "/"
-            + str(user_id_student)
-            + "/"
-            + str(lms_user_id)
-            + path_contactform
+                path_user
+                + "/"
+                + str(user_id_student)
+                + "/"
+                + str(lms_user_id)
+                + path_contactform
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3292,7 +3320,7 @@ class TestApi:
         ],
     )
     def test_delete_user(
-        self, client_class, moodle_user_id, keys_expected, status_code_expected, student
+            self, client_class, moodle_user_id, keys_expected, status_code_expected, student
     ):
         global user_id_student, user_id_teacher
         if student:
@@ -3324,16 +3352,16 @@ class TestApi:
         ],
     )
     def test_api_delete_le_from_moodle(
-        self,
-        client_class,
-        moodle_course_id,
-        moodle_topic_id,
-        moodle_learning_element_id,
-        keys_expected,
-        status_code_expected,
-        error_course,
-        error_topic,
-        error_le,
+            self,
+            client_class,
+            moodle_course_id,
+            moodle_topic_id,
+            moodle_learning_element_id,
+            keys_expected,
+            status_code_expected,
+            error_course,
+            error_topic,
+            error_le,
     ):
         global course_id, sub_topic_id, learning_element_id
         if error_course:
@@ -3349,21 +3377,21 @@ class TestApi:
         else:
             learning_element_id_use = learning_element_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id_use)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + "/"
-            + str(moodle_topic_id)
-            + path_learning_element
-            + "/"
-            + str(learning_element_id_use)
-            + "/"
-            + str(moodle_learning_element_id)
+                path_lms_course
+                + "/"
+                + str(course_id_use)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + "/"
+                + str(moodle_topic_id)
+                + path_learning_element
+                + "/"
+                + str(learning_element_id_use)
+                + "/"
+                + str(moodle_learning_element_id)
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3386,14 +3414,14 @@ class TestApi:
         ],
     )
     def test_api_delete_topic_from_moodle(
-        self,
-        client_class,
-        moodle_course_id,
-        moodle_topic_id,
-        keys_expected,
-        status_code_expected,
-        error_course,
-        error_topic,
+            self,
+            client_class,
+            moodle_course_id,
+            moodle_topic_id,
+            keys_expected,
+            status_code_expected,
+            error_course,
+            error_topic,
     ):
         global course_id, sub_topic_id
         if error_course:
@@ -3405,16 +3433,16 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-            path_lms_course
-            + "/"
-            + str(course_id_use)
-            + "/"
-            + str(moodle_course_id)
-            + path_topic
-            + "/"
-            + str(topic_id_use)
-            + "/"
-            + str(moodle_topic_id)
+                path_lms_course
+                + "/"
+                + str(course_id_use)
+                + "/"
+                + str(moodle_course_id)
+                + path_topic
+                + "/"
+                + str(topic_id_use)
+                + "/"
+                + str(moodle_topic_id)
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3434,7 +3462,7 @@ class TestApi:
         ],
     )
     def test_api_delete_course_from_moodle(
-        self, client_class, moodle_course_id, keys_expected, status_code_expected, error
+            self, client_class, moodle_course_id, keys_expected, status_code_expected, error
     ):
         global course_id
         if error:

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,5 +1,6 @@
 import json
 from unittest import mock
+
 import pytest
 
 user_id_admin = 0

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2490,13 +2490,12 @@ class TestApi:
                 + path_student
                 + "/"
                 + str(student_id)
-                + "/"
                 + path_activity_status
         )
         r = client_class.get(url)
-        #assert r.status_code == 200
-        #response = json.loads(r.data.decode("utf-8").strip("\n"))
-        #assert "activity_status" in response.keys()
+        assert r.status_code == 200
+        response = json.loads(r.data.decode("utf-8").strip("\n"))
+        assert "cmid" in response.statuses[0].keys()
 
     # PUT METHODS
     # Update the settings of a User

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2470,6 +2470,34 @@ class TestApi:
         for key in keys_expected:
             assert key in response.keys()
 
+    # Get all learning element statuses for a student for a course
+    #@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @pytest.mark.parametrize(
+        "course_id, student_id",
+        [
+            # Working Example
+            (1, 1)
+        ],
+    )
+    def test_get_activity_status_for_student(
+            self, client_class, course_id, student_id
+    ):
+        global user_id_student
+        url = (
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + "/"
+                + path_activity_status
+        )
+        r = client_class.get(url)
+        #assert r.status_code == 200
+        #response = json.loads(r.data.decode("utf-8").strip("\n"))
+        #assert "activity_status" in response.keys()
+
     # PUT METHODS
     # Update the settings of a User
     @pytest.mark.parametrize(
@@ -2990,33 +3018,6 @@ class TestApi:
         response = json.loads(r.data.decode("utf-8").strip("\n"))
         for key in keys_expected:
             assert key in response.keys()
-
-    # Get all learning element statuses for a student for a course
-    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
-    @pytest.mark.parametrize(
-        "course_id, student_id",
-        [
-            # Working Example
-            (1, 1)
-        ],
-    )
-    def test_get_activity_status_for_student(
-            self, client_class, course_id, student_id
-    ):
-        global user_id_student
-        url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + "/"
-                + path_activity_status
-        )
-        r = client_class.get(url)
-        #response = json.loads(r.data.decode("utf-8").strip("\n"))
-        #assert "activity_status" in response.keys()
 
     # DELETE METHODS
     # Reset User Settings

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2500,7 +2500,8 @@ class TestApi:
     # Get all learning element statuses for a student for a course
     @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
     @pytest.mark.parametrize(
-        "course_id, student_id",
+        "course_id, student_id, \
+                            learning_element_id",
         [
             # Working Example
             (1, 1, 2)
@@ -2517,9 +2518,9 @@ class TestApi:
                 + path_student
                 + "/"
                 + str(student_id)
+                + "/"
                 + "learningElementId/"
                 + str(learning_element_id)
-                + "/"
                 + path_activity_status
         )
         r = client_class.get(url)

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -235,130 +235,130 @@ class TestApi:
         [
             # Working Example Admin
             (
-                    {
-                        "name": "Achim Admin",
-                        "lms_user_id": 1,
-                        "role": "Admin",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    [
-                        "id",
-                        "name",
-                        "university",
-                        "lms_user_id",
-                        "role",
-                        "role_id",
-                        "settings",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Achim Admin",
+                    "lms_user_id": 1,
+                    "role": "Admin",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                [
+                    "id",
+                    "name",
+                    "university",
+                    "lms_user_id",
+                    "role",
+                    "role_id",
+                    "settings",
+                ],
+                201,
+                True,
             ),
             # Working Example Course Creator
             (
-                    {
-                        "name": "Claus Creator",
-                        "lms_user_id": 2,
-                        "role": "Course Creator",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    [
-                        "id",
-                        "name",
-                        "university",
-                        "lms_user_id",
-                        "role",
-                        "role_id",
-                        "settings",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Claus Creator",
+                    "lms_user_id": 2,
+                    "role": "Course Creator",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                [
+                    "id",
+                    "name",
+                    "university",
+                    "lms_user_id",
+                    "role",
+                    "role_id",
+                    "settings",
+                ],
+                201,
+                True,
             ),
             # Working Example Teacher
             (
-                    {
-                        "name": "Tim Teacher",
-                        "lms_user_id": 3,
-                        "role": "Teacher",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    [
-                        "id",
-                        "name",
-                        "university",
-                        "lms_user_id",
-                        "role",
-                        "role_id",
-                        "settings",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Tim Teacher",
+                    "lms_user_id": 3,
+                    "role": "Teacher",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                [
+                    "id",
+                    "name",
+                    "university",
+                    "lms_user_id",
+                    "role",
+                    "role_id",
+                    "settings",
+                ],
+                201,
+                True,
             ),
             # Working Example Student
             (
-                    {
-                        "name": "Sonja Studentin",
-                        "lms_user_id": 4,
-                        "role": "Student",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    [
-                        "id",
-                        "name",
-                        "university",
-                        "lms_user_id",
-                        "role",
-                        "role_id",
-                        "settings",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Sonja Studentin",
+                    "lms_user_id": 4,
+                    "role": "Student",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                [
+                    "id",
+                    "name",
+                    "university",
+                    "lms_user_id",
+                    "role",
+                    "role_id",
+                    "settings",
+                ],
+                201,
+                True,
             ),
             # Missing Parameter
             (
-                    {
-                        "lms_user_id": 1,
-                        "role": "Student",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "lms_user_id": 1,
+                    "role": "Student",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "name": "Max Mustermann",
-                        "lms_user_id": "1",
-                        "role": "Student",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Max Mustermann",
+                    "lms_user_id": "1",
+                    "role": "Student",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
             # User already exists
             (
-                    {
-                        "name": "Achim Admin",
-                        "lms_user_id": 1,
-                        "role": "Admin",
-                        "university": "TH-AB",
-                        "password": "password",
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Achim Admin",
+                    "lms_user_id": 1,
+                    "role": "Admin",
+                    "university": "TH-AB",
+                    "password": "password",
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_api_create_user_from_moodle(
-            self, client_class, input, keys_expected, status_code_expected, save_id
+        self, client_class, input, keys_expected, status_code_expected, save_id
     ):
         url = path_lms_user
         r = client_class.post(url, json=input)
@@ -392,51 +392,51 @@ class TestApi:
         [
             # Working Example
             (
-                    {
-                        "name": "Test Course",
-                        "lms_id": 1,
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    ["id", "name", "lms_id", "created_at", "created_by", "university"],
-                    201,
-                    True,
+                {
+                    "name": "Test Course",
+                    "lms_id": 1,
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                ["id", "name", "lms_id", "created_at", "created_by", "university"],
+                201,
+                True,
             ),
             # Missing Parameter
             (
-                    {"name": "Test Course", "university": "TH-AB"},
-                    ["error", "message"],
-                    400,
-                    False,
+                {"name": "Test Course", "university": "TH-AB"},
+                ["error", "message"],
+                400,
+                False,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "name": "Test Course",
-                        "lms_id": "1",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Course",
+                    "lms_id": "1",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
             # Course already exists
             (
-                    {
-                        "name": "Test Course",
-                        "lms_id": 1,
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Course",
+                    "lms_id": 1,
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_api_create_course_from_moodle(
-            self, client_class, input, keys_expected, status_code_expected, save_id
+        self, client_class, input, keys_expected, status_code_expected, save_id
     ):
         global user_id_course_creator
         input["created_by"] = user_id_course_creator
@@ -457,123 +457,123 @@ class TestApi:
         [
             # Working Example for Topic
             (
-                    {
-                        "name": "Test Topic",
-                        "lms_id": 1,
-                        "is_topic": True,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    [
-                        "id",
-                        "name",
-                        "lms_id",
-                        "is_topic",
-                        "parent_id",
-                        "contains_le",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Test Topic",
+                    "lms_id": 1,
+                    "is_topic": True,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                [
+                    "id",
+                    "name",
+                    "lms_id",
+                    "is_topic",
+                    "parent_id",
+                    "contains_le",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
+                True,
             ),
             # Working Example for Sub-Topic
             (
-                    {
-                        "name": "Test Sub-Topic",
-                        "lms_id": 2,
-                        "is_topic": False,
-                        "parent_id": 1,
-                        "contains_le": True,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    [
-                        "id",
-                        "name",
-                        "lms_id",
-                        "is_topic",
-                        "parent_id",
-                        "contains_le",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Test Sub-Topic",
+                    "lms_id": 2,
+                    "is_topic": False,
+                    "parent_id": 1,
+                    "contains_le": True,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                [
+                    "id",
+                    "name",
+                    "lms_id",
+                    "is_topic",
+                    "parent_id",
+                    "contains_le",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
+                True,
             ),
             # Missing Parameter
             (
-                    {
-                        "name": "Test Topic",
-                        "is_topic": True,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Topic",
+                    "is_topic": True,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "name": "Test Topic",
-                        "lms_id": "1",
-                        "is_topic": True,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Topic",
+                    "lms_id": "1",
+                    "is_topic": True,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
             # Topic already exists
             (
-                    {
-                        "name": "Test Topic",
-                        "lms_id": 1,
-                        "is_topic": True,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Topic",
+                    "lms_id": 1,
+                    "is_topic": True,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_api_create_topic_from_moodle(
-            self,
-            client_class,
-            input,
-            moodle_course_id,
-            keys_expected,
-            status_code_expected,
-            save_id,
+        self,
+        client_class,
+        input,
+        moodle_course_id,
+        keys_expected,
+        status_code_expected,
+        save_id,
     ):
         global course_id, topic_id, sub_topic_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
         )
         if topic_id != 0:
             input["parent_id"] = topic_id
@@ -596,106 +596,106 @@ class TestApi:
         [
             # Working Example for LE
             (
-                    {
-                        "lms_id": 1,
-                        "activity_type": "Quiz",
-                        "classification": "RQ",
-                        "name": "Test Learning Element",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
-                    True,
+                {
+                    "lms_id": 1,
+                    "activity_type": "Quiz",
+                    "classification": "RQ",
+                    "name": "Test Learning Element",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
+                True,
             ),
             # Missing Parameter
             (
-                    {
-                        "lms_id": 1,
-                        "classification": "RQ",
-                        "name": "Test Learning Element",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "lms_id": 1,
+                    "classification": "RQ",
+                    "name": "Test Learning Element",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "lms_id": "1",
-                        "activity_type": "Quiz",
-                        "classification": "RQ",
-                        "name": "Test Learning Element",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "lms_id": "1",
+                    "activity_type": "Quiz",
+                    "classification": "RQ",
+                    "name": "Test Learning Element",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
             # LE already exists
             (
-                    {
-                        "lms_id": 1,
-                        "activity_type": "Quiz",
-                        "classification": "RQ",
-                        "name": "Test Learning Element",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "lms_id": 1,
+                    "activity_type": "Quiz",
+                    "classification": "RQ",
+                    "name": "Test Learning Element",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_api_create_le_from_moodle(
-            self,
-            client_class,
-            input,
-            moodle_course_id,
-            moodle_topic_id,
-            keys_expected,
-            status_code_expected,
-            save_id,
+        self,
+        client_class,
+        input,
+        moodle_course_id,
+        moodle_topic_id,
+        keys_expected,
+        status_code_expected,
+        save_id,
     ):
         global course_id
         global sub_topic_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
-                + "/"
-                + str(sub_topic_id)
-                + "/"
-                + str(moodle_topic_id)
-                + path_learning_element
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
+            + "/"
+            + str(sub_topic_id)
+            + "/"
+            + str(moodle_topic_id)
+            + path_learning_element
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -722,12 +722,12 @@ class TestApi:
         ],
     )
     def test_add_teacher_to_course(
-            self,
-            client_class,
-            error_teacher,
-            error_course,
-            keys_expected,
-            status_code_expected,
+        self,
+        client_class,
+        error_teacher,
+        error_course,
+        keys_expected,
+        status_code_expected,
     ):
         global course_id, teacher_id
         if error_teacher:
@@ -739,12 +739,12 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id_use)
-                + path_teacher
-                + "/"
-                + str(teacher_id_use)
+            path_lms_course
+            + "/"
+            + str(course_id_use)
+            + path_teacher
+            + "/"
+            + str(teacher_id_use)
         )
         r = client_class.post(url)
         assert r.status_code == status_code_expected
@@ -759,22 +759,22 @@ class TestApi:
         [
             # Working Example
             (
-                    False,
-                    False,
-                    [
-                        "id",
-                        "course_id",
-                        "student_id",
-                        "input_dimension",
-                        "input_value",
-                        "perception_dimension",
-                        "perception_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    201,
+                False,
+                False,
+                [
+                    "id",
+                    "course_id",
+                    "student_id",
+                    "input_dimension",
+                    "input_value",
+                    "perception_dimension",
+                    "perception_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                201,
             ),
             # Student not found
             (True, False, ["error", "message"], 404),
@@ -785,12 +785,12 @@ class TestApi:
         ],
     )
     def test_add_student_to_course(
-            self,
-            client_class,
-            error_student,
-            error_course,
-            keys_expected,
-            status_code_expected,
+        self,
+        client_class,
+        error_student,
+        error_course,
+        keys_expected,
+        status_code_expected,
     ):
         global course_id, student_id
         if error_student:
@@ -802,12 +802,12 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id_use)
-                + path_student
-                + "/"
-                + str(student_id_use)
+            path_lms_course
+            + "/"
+            + str(course_id_use)
+            + path_student
+            + "/"
+            + str(student_id_use)
         )
         r = client_class.post(url)
         assert r.status_code == status_code_expected
@@ -822,33 +822,33 @@ class TestApi:
         [
             # Working example
             (
-                    1,
-                    [
-                        "att",
-                        "characteristic_id",
-                        "cogn_str",
-                        "con",
-                        "crit_rev",
-                        "eff",
-                        "elab",
-                        "ext_res_mng_str",
-                        "goal_plan",
-                        "id",
-                        "int_res_mng_str",
-                        "lit_res",
-                        "lrn_env",
-                        "lrn_w_cls",
-                        "metacogn_str",
-                        "org",
-                        "reg",
-                        "rep",
-                        "time",
-                    ],
-                    201,
-                    True,
-                    False,
-                    False,
-                    False,
+                1,
+                [
+                    "att",
+                    "characteristic_id",
+                    "cogn_str",
+                    "con",
+                    "crit_rev",
+                    "eff",
+                    "elab",
+                    "ext_res_mng_str",
+                    "goal_plan",
+                    "id",
+                    "int_res_mng_str",
+                    "lit_res",
+                    "lrn_env",
+                    "lrn_w_cls",
+                    "metacogn_str",
+                    "org",
+                    "reg",
+                    "rep",
+                    "time",
+                ],
+                201,
+                True,
+                False,
+                False,
+                False,
             ),
             # Missing mandatory answer
             (1, ["error", "message"], 400, False, True, False, False),
@@ -859,15 +859,15 @@ class TestApi:
         ],
     )
     def test_post_questionnaire_list_k(
-            self,
-            client_class,
-            student_id,
-            keys_expected,
-            status_code_expected,
-            save_id,
-            error_id_missing,
-            error_answer_list_k,
-            error_list_k_id,
+        self,
+        client_class,
+        student_id,
+        keys_expected,
+        status_code_expected,
+        save_id,
+        error_id_missing,
+        error_answer_list_k,
+        error_list_k_id,
     ):
         json_input = {}
         list_k = []
@@ -903,47 +903,47 @@ class TestApi:
         [
             # Working example
             (
-                    True,
-                    1,
-                    [
-                        "characteristic_id",
-                        "id",
-                        "input_dimension",
-                        "input_value",
-                        "perception_dimension",
-                        "perception_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    201,
-                    True,
-                    False,
-                    False,
-                    False,
+                True,
+                1,
+                [
+                    "characteristic_id",
+                    "id",
+                    "input_dimension",
+                    "input_value",
+                    "perception_dimension",
+                    "perception_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                201,
+                True,
+                False,
+                False,
+                False,
             ),
             # Working example short questionnaire
             (
-                    False,
-                    1,
-                    [
-                        "characteristic_id",
-                        "id",
-                        "input_dimension",
-                        "input_value",
-                        "perception_dimension",
-                        "perception_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    201,
-                    True,
-                    False,
-                    False,
-                    False,
+                False,
+                1,
+                [
+                    "characteristic_id",
+                    "id",
+                    "input_dimension",
+                    "input_value",
+                    "perception_dimension",
+                    "perception_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                201,
+                True,
+                False,
+                False,
+                False,
             ),
             # Missing mandatory answer
             (False, 1, ["error", "message"], 400, False, True, False, False),
@@ -954,16 +954,16 @@ class TestApi:
         ],
     )
     def test_post_questionnaire_ils(
-            self,
-            client_class,
-            ils_long,
-            student_id,
-            keys_expected,
-            status_code_expected,
-            save_id,
-            error_id_missing,
-            error_key_wrong,
-            error_answer_ils,
+        self,
+        client_class,
+        ils_long,
+        student_id,
+        keys_expected,
+        status_code_expected,
+        save_id,
+        error_id_missing,
+        error_key_wrong,
+        error_answer_ils,
     ):
         json_input = {}
         ils = []
@@ -1013,10 +1013,10 @@ class TestApi:
         [
             # Working Example
             (
-                    {"visit_start": "2023-08-01T13:37:42Z"},
-                    4,
-                    ["id", "student_id", "topic_id", "visit_start", "visit_end"],
-                    201,
+                {"visit_start": "2023-08-01T13:37:42Z"},
+                4,
+                ["id", "student_id", "topic_id", "visit_start", "visit_end"],
+                201,
             ),
             # Wrong data format
             ({"visit_start": "01.01.2023"}, 4, ["error", "message"], 400),
@@ -1025,18 +1025,18 @@ class TestApi:
         ],
     )
     def test_post_topic_visit(
-            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global student_id, topic_id
         url = (
-                path_lms_student
-                + "/"
-                + str(student_id)
-                + "/"
-                + str(moodle_user_id)
-                + path_topic
-                + "/"
-                + str(topic_id)
+            path_lms_student
+            + "/"
+            + str(student_id)
+            + "/"
+            + str(moodle_user_id)
+            + path_topic
+            + "/"
+            + str(topic_id)
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1051,10 +1051,10 @@ class TestApi:
         [
             # Working Example
             (
-                    {"visit_start": "2023-08-01T13:37:42Z"},
-                    4,
-                    ["student_id", "learning_element_id", "visit_start", "visit_end"],
-                    201,
+                {"visit_start": "2023-08-01T13:37:42Z"},
+                4,
+                ["student_id", "learning_element_id", "visit_start", "visit_end"],
+                201,
             ),
             # Wrong data format
             ({"visit_start_time": "01.01.2023"}, 4, ["error", "message"], 400),
@@ -1063,18 +1063,18 @@ class TestApi:
         ],
     )
     def test_post_learning_element_visit(
-            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global student_id, learning_element_id
         url = (
-                path_lms_student
-                + "/"
-                + str(student_id)
-                + "/"
-                + str(moodle_user_id)
-                + path_learning_element
-                + "/"
-                + str(learning_element_id)
+            path_lms_student
+            + "/"
+            + str(student_id)
+            + "/"
+            + str(moodle_user_id)
+            + path_learning_element
+            + "/"
+            + str(learning_element_id)
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1089,43 +1089,95 @@ class TestApi:
         [
             # Working Example ACO
             (
-                    {"algorithm": "aco"},
-                    4,
-                    [
-                        "id",
-                        "course_id",
-                        "topic_id",
-                        "student_id",
-                        "based_on",
-                        "path",
-                        "calculated_on",
-                    ],
-                    201,
+                {"algorithm": "aco"},
+                4,
+                [
+                    "id",
+                    "course_id",
+                    "topic_id",
+                    "student_id",
+                    "based_on",
+                    "path",
+                    "calculated_on",
+                ],
+                201,
             ),
             # Working Example Graf
             (
-                    {"algorithm": "graf"},
-                    4,
-                    [
-                        "id",
-                        "course_id",
-                        "topic_id",
-                        "student_id",
-                        "based_on",
-                        "path",
-                        "calculated_on",
-                    ],
-                    201,
+                {"algorithm": "graf"},
+                4,
+                [
+                    "id",
+                    "course_id",
+                    "topic_id",
+                    "student_id",
+                    "based_on",
+                    "path",
+                    "calculated_on",
+                ],
+                201,
             ),
             # Missing Parameter
             ({}, 4, ["error", "message"], 400),
         ],
     )
     def test_post_learning_path(
-            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         url = (
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(moodle_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_course
+            + "/"
+            + str(course_id)
+            + path_topic
+            + "/"
+            + str(sub_topic_id)
+            + path_learning_path
+        )
+        r = client_class.post(url, json=input)
+        assert r.status_code == status_code_expected
+        response = json.loads(r.data.decode("utf-8").strip("\n"))
+        for key in keys_expected:
+            assert key in response.keys()
+
+    # Learning Path is calculated for ga
+    @pytest.mark.parametrize(
+        "input, moodle_user_id, keys_exp,\
+                            status_code_exp",
+        [
+            # Working Example
+            (
+                {"algorithm": "ga"},
+                4,
+                [
+                    "id",
+                    "course_id",
+                    "topic_id",
+                    "student_id",
+                    "based_on",
+                    "path",
+                    "calculated_on",
+                ],
+                201,
+            ),
+            # Missing Parameter
+            ({}, 4, ["error", "message"], 400),
+        ],
+    )
+    def test_post_learning_path_ga(
+        self, client_class, input, moodle_user_id, keys_exp, status_code_exp
+    ):
+        global user_id_student, student_id, course_id2, sub_topic_id2
+        client_post = client_class.post(
+            (
                 path_user
                 + "/"
                 + str(user_id_student)
@@ -1141,58 +1193,6 @@ class TestApi:
                 + "/"
                 + str(sub_topic_id)
                 + path_learning_path
-        )
-        r = client_class.post(url, json=input)
-        assert r.status_code == status_code_expected
-        response = json.loads(r.data.decode("utf-8").strip("\n"))
-        for key in keys_expected:
-            assert key in response.keys()
-
-    # Learning Path is calculated for ga
-    @pytest.mark.parametrize(
-        "input, moodle_user_id, keys_exp,\
-                            status_code_exp",
-        [
-            # Working Example
-            (
-                    {"algorithm": "ga"},
-                    4,
-                    [
-                        "id",
-                        "course_id",
-                        "topic_id",
-                        "student_id",
-                        "based_on",
-                        "path",
-                        "calculated_on",
-                    ],
-                    201,
-            ),
-            # Missing Parameter
-            ({}, 4, ["error", "message"], 400),
-        ],
-    )
-    def test_post_learning_path_ga(
-            self, client_class, input, moodle_user_id, keys_exp, status_code_exp
-    ):
-        global user_id_student, student_id, course_id2, sub_topic_id2
-        client_post = client_class.post(
-            (
-                    path_user
-                    + "/"
-                    + str(user_id_student)
-                    + "/"
-                    + str(moodle_user_id)
-                    + path_student
-                    + "/"
-                    + str(student_id)
-                    + path_course
-                    + "/"
-                    + str(course_id)
-                    + path_topic
-                    + "/"
-                    + str(sub_topic_id)
-                    + path_learning_path
             ),
             json=input,
         )
@@ -1208,36 +1208,36 @@ class TestApi:
         [
             # Working Example
             (
-                    {
-                        "report_topic": "Lernelement",
-                        "report_type": "Funktionalität",
-                        "report_description": "Test",
-                    },
-                    4,
-                    [
-                        "id",
-                        "user_id",
-                        "report_topic",
-                        "report_type",
-                        "report_description",
-                    ],
-                    201,
+                {
+                    "report_topic": "Lernelement",
+                    "report_type": "Funktionalität",
+                    "report_description": "Test",
+                },
+                4,
+                [
+                    "id",
+                    "user_id",
+                    "report_topic",
+                    "report_type",
+                    "report_description",
+                ],
+                201,
             ),
             # Missing Parameter
             ({}, 4, ["error", "message"], 400),
         ],
     )
     def test_post_contact_form(
-            self, client_class, input, lms_user_id, keys_expected, status_code_expected
+        self, client_class, input, lms_user_id, keys_expected, status_code_expected
     ):
         user_id_student = 4
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_contactform
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_contactform
         )
         r = client_class.post(url, json=input)
         assert r.status_code == status_code_expected
@@ -1251,79 +1251,79 @@ class TestApi:
         [
             # Working Example
             (
-                    {
-                        "name": "FCP",
-                        "value": 3957.6999999284744,
-                        "rating": "poor",
-                        "delta": 3957.6999999284744,
-                        "entries": [
-                            {
-                                "name": "first-contentful-paint",
-                                "entryType": "paint",
-                                "startTime": 3957.6999999284744,
-                                "duration": 0,
-                            },
-                            {
-                                "name": "http://localhost:8080/",
-                                "entryType": "navigation",
-                                "startTime": 0,
-                                "duration": 4003.0999999046326,
-                                "initiatorType": "navigation",
-                                "nextHopProtocol": "http/1.1",
-                                "workerStart": 0,
-                                "redirectStart": 0,
-                                "redirectEnd": 0,
-                                "fetchStart": 7.699999928474426,
-                                "domainLookupStart": 99.19999992847443,
-                                "domainLookupEnd": 99.29999995231628,
-                                "connectStart": 99.29999995231628,
-                                "connectEnd": 99.89999997615814,
-                                "secureConnectionStart": "0,",
-                                "requestStart": 100,
-                                "responseStart": 3638.7999999523163,
-                                "responseEnd": 3640,
-                                "transferSize": 810,
-                                "encodedBodySize": 510,
-                                "decodedBodySize": 510,
-                                "serverTiming": [""],
-                                "workerTiming": [""],
-                                "unloadEventStart": 0,
-                                "unloadEventEnd": 0,
-                                "domInteractive": 3717.5,
-                                "domContentLoadedEventStart": 3937.5999999046326,
-                                "domContentLoadedEventEnd": 3938.899999976158,
-                                "domComplete": 4003.0999999046326,
-                                "loadEventStart": 4003.0999999046326,
-                                "loadEventEnd": 4003.0999999046326,
-                                "type": "navigate",
-                                "redirectCount": 0,
-                            },
-                            {},
-                            {
-                                "name": "",
-                                "entryType": "largest-contentful-paint",
-                                "startTime": 3957.699,
-                                "duration": 0,
-                                "size": 867,
-                                "renderTime": 3957.699,
-                                "loadTime": 0,
-                                "firstAnimatedFrameTime": 0,
-                                "id": "",
-                                "url": "",
-                            },
-                            {},
-                            {},
-                        ],
-                        "id": "v3-1665068191217-4248786867866",
-                        "navigationType": "navigate",
-                    },
-                    ["name", "value", "rating", "delta", "entries", "id", "navigationType"],
-                    201,
+                {
+                    "name": "FCP",
+                    "value": 3957.6999999284744,
+                    "rating": "poor",
+                    "delta": 3957.6999999284744,
+                    "entries": [
+                        {
+                            "name": "first-contentful-paint",
+                            "entryType": "paint",
+                            "startTime": 3957.6999999284744,
+                            "duration": 0,
+                        },
+                        {
+                            "name": "http://localhost:8080/",
+                            "entryType": "navigation",
+                            "startTime": 0,
+                            "duration": 4003.0999999046326,
+                            "initiatorType": "navigation",
+                            "nextHopProtocol": "http/1.1",
+                            "workerStart": 0,
+                            "redirectStart": 0,
+                            "redirectEnd": 0,
+                            "fetchStart": 7.699999928474426,
+                            "domainLookupStart": 99.19999992847443,
+                            "domainLookupEnd": 99.29999995231628,
+                            "connectStart": 99.29999995231628,
+                            "connectEnd": 99.89999997615814,
+                            "secureConnectionStart": "0,",
+                            "requestStart": 100,
+                            "responseStart": 3638.7999999523163,
+                            "responseEnd": 3640,
+                            "transferSize": 810,
+                            "encodedBodySize": 510,
+                            "decodedBodySize": 510,
+                            "serverTiming": [""],
+                            "workerTiming": [""],
+                            "unloadEventStart": 0,
+                            "unloadEventEnd": 0,
+                            "domInteractive": 3717.5,
+                            "domContentLoadedEventStart": 3937.5999999046326,
+                            "domContentLoadedEventEnd": 3938.899999976158,
+                            "domComplete": 4003.0999999046326,
+                            "loadEventStart": 4003.0999999046326,
+                            "loadEventEnd": 4003.0999999046326,
+                            "type": "navigate",
+                            "redirectCount": 0,
+                        },
+                        {},
+                        {
+                            "name": "",
+                            "entryType": "largest-contentful-paint",
+                            "startTime": 3957.699,
+                            "duration": 0,
+                            "size": 867,
+                            "renderTime": 3957.699,
+                            "loadTime": 0,
+                            "firstAnimatedFrameTime": 0,
+                            "id": "",
+                            "url": "",
+                        },
+                        {},
+                        {},
+                    ],
+                    "id": "v3-1665068191217-4248786867866",
+                    "navigationType": "navigate",
+                },
+                ["name", "value", "rating", "delta", "entries", "id", "navigationType"],
+                201,
             )
         ],
     )
     def test_api_post_frontend_logs(
-            self, client_class, input, keys_expected, status_code_expected
+        self, client_class, input, keys_expected, status_code_expected
     ):
         url = path_frontend_logs
         r = client_class.post(url, json=input)
@@ -1340,22 +1340,22 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    [
-                        "learning_style",
-                        "learning_strategy",
-                        "learning_analytics",
-                        "knowledge",
-                    ],
-                    False,
+                4,
+                200,
+                [
+                    "learning_style",
+                    "learning_strategy",
+                    "learning_analytics",
+                    "knowledge",
+                ],
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True),
         ],
     )
     def test_get_students_learning_characteristics(
-            self, client_class, lms_user_id, status_code_expected, keys_expected, error
+        self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1363,15 +1363,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_learning_characteristics
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_learning_characteristics
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1391,7 +1391,7 @@ class TestApi:
         ],
     )
     def test_get_students_learning_analytics(
-            self, client_class, lms_user_id, status_code_expected, keys_expected, error
+        self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1399,15 +1399,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_learning_analytics
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_learning_analytics
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1422,26 +1422,26 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    [
-                        "perception_dimension",
-                        "perception_value",
-                        "input_dimension",
-                        "input_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    False,
+                4,
+                200,
+                [
+                    "perception_dimension",
+                    "perception_value",
+                    "input_dimension",
+                    "input_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True),
         ],
     )
     def test_get_students_learning_style(
-            self, client_class, lms_user_id, status_code_expected, keys_expected, error
+        self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1449,15 +1449,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_learning_style
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_learning_style
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1477,7 +1477,7 @@ class TestApi:
         ],
     )
     def test_get_students_learning_strategy(
-            self, client_class, lms_user_id, status_code_expected, keys_expected, error
+        self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1485,15 +1485,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_learning_strategy
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_learning_strategy
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1513,7 +1513,7 @@ class TestApi:
         ],
     )
     def test_get_students_knowledge(
-            self, client_class, lms_user_id, status_code_expected, keys_expected, error
+        self, client_class, lms_user_id, status_code_expected, keys_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -1521,15 +1521,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_knowledge
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_knowledge
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1549,13 +1549,13 @@ class TestApi:
         ],
     )
     def test_get_student_courses(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected_1,
-            keys_expected_2,
-            error,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected_1,
+        keys_expected_2,
+        error,
     ):
         global user_id_student, student_id
         if error:
@@ -1563,15 +1563,15 @@ class TestApi:
         else:
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1600,13 +1600,13 @@ class TestApi:
         ],
     )
     def test_get_student_course(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected,
-            error_student,
-            error_course,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected,
+        error_student,
+        error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1618,17 +1618,17 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1644,21 +1644,21 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    ["topics"],
-                    [
-                        "id",
-                        "lms_id",
-                        "name",
-                        "is_topic",
-                        "contains_le",
-                        "university",
-                        "parent_id",
-                        "student_topic",
-                    ],
-                    False,
-                    False,
+                4,
+                200,
+                ["topics"],
+                [
+                    "id",
+                    "lms_id",
+                    "name",
+                    "is_topic",
+                    "contains_le",
+                    "university",
+                    "parent_id",
+                    "student_topic",
+                ],
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False),
@@ -1667,14 +1667,14 @@ class TestApi:
         ],
     )
     def test_get_student_course_topics(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected_1,
-            keys_expected_2,
-            error_student,
-            error_course,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected_1,
+        keys_expected_2,
+        error_student,
+        error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1686,18 +1686,18 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1719,20 +1719,20 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    ["learning_elements"],
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "university",
-                        "student_learning_element",
-                    ],
-                    False,
-                    False,
+                4,
+                200,
+                ["learning_elements"],
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "university",
+                    "student_learning_element",
+                ],
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False),
@@ -1741,14 +1741,14 @@ class TestApi:
         ],
     )
     def test_get_les_in_course_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected_1,
-            keys_expected_2,
-            error_student,
-            error_course,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected_1,
+        keys_expected_2,
+        error_student,
+        error_course,
     ):
         global user_id_student, student_id, course_id
         if error_student:
@@ -1760,18 +1760,18 @@ class TestApi:
         else:
             course_id_use = course_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_learning_element
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_learning_element
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1793,21 +1793,21 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    [
-                        "id",
-                        "lms_id",
-                        "name",
-                        "is_topic",
-                        "contains_le",
-                        "university",
-                        "parent_id",
-                        "student_topic",
-                    ],
-                    False,
-                    False,
-                    False,
+                4,
+                200,
+                [
+                    "id",
+                    "lms_id",
+                    "name",
+                    "is_topic",
+                    "contains_le",
+                    "university",
+                    "parent_id",
+                    "student_topic",
+                ],
+                False,
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False),
@@ -1818,14 +1818,14 @@ class TestApi:
         ],
     )
     def test_get_topic_by_id_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected,
-            error_student,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected,
+        error_student,
+        error_course,
+        error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -1841,20 +1841,20 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1870,20 +1870,20 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "university",
-                        "student_learning_element",
-                    ],
-                    200,
-                    False,
-                    False,
-                    False,
+                4,
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "university",
+                    "student_learning_element",
+                ],
+                200,
+                False,
+                False,
+                False,
             ),
             # User not found
             (1, ["error", "message"], 404, True, False, False),
@@ -1894,14 +1894,14 @@ class TestApi:
         ],
     )
     def test_get_topic_recommendation_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            keys_expected,
-            status_code_expected,
-            error_student,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        lms_user_id,
+        keys_expected,
+        status_code_expected,
+        error_student,
+        error_course,
+        error_topic,
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         if error_student:
@@ -1917,21 +1917,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + path_recommendation
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + path_recommendation
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -1947,20 +1947,20 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    [
-                        "id",
-                        "course_id",
-                        "topic_id",
-                        "student_id",
-                        "based_on",
-                        "calculated_on",
-                        "path",
-                    ],
-                    False,
-                    False,
-                    False,
+                4,
+                200,
+                [
+                    "id",
+                    "course_id",
+                    "topic_id",
+                    "student_id",
+                    "based_on",
+                    "calculated_on",
+                    "path",
+                ],
+                False,
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False),
@@ -1971,14 +1971,14 @@ class TestApi:
         ],
     )
     def test_get_learning_path_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected,
-            error_student,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected,
+        error_student,
+        error_course,
+        error_topic,
     ):
         global user_id_student, student_id, course_id, sub_topic_id
         if error_student:
@@ -1994,21 +1994,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + path_learning_path
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + path_learning_path
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2024,22 +2024,22 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    ["topics"],
-                    [
-                        "id",
-                        "lms_id",
-                        "name",
-                        "is_topic",
-                        "contains_le",
-                        "university",
-                        "parent_id",
-                        "student_topic",
-                    ],
-                    False,
-                    False,
-                    False,
+                4,
+                200,
+                ["topics"],
+                [
+                    "id",
+                    "lms_id",
+                    "name",
+                    "is_topic",
+                    "contains_le",
+                    "university",
+                    "parent_id",
+                    "student_topic",
+                ],
+                False,
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False, False),
@@ -2050,15 +2050,15 @@ class TestApi:
         ],
     )
     def test_get_sub_topics_for_topic(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected_1,
-            keys_expected_2,
-            error_student,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected_1,
+        keys_expected_2,
+        error_student,
+        error_course,
+        error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -2074,21 +2074,21 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + path_subtopic
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + path_subtopic
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2111,21 +2111,21 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    ["learning_elements"],
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "university",
-                        "student_learning_element",
-                    ],
-                    False,
-                    False,
-                    False,
+                4,
+                200,
+                ["learning_elements"],
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "university",
+                    "student_learning_element",
+                ],
+                False,
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], [], True, False, False),
@@ -2136,15 +2136,15 @@ class TestApi:
         ],
     )
     def test_get_les_for_topic_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected_1,
-            keys_expected_2,
-            error_student,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected_1,
+        keys_expected_2,
+        error_student,
+        error_course,
+        error_topic,
     ):
         global user_id_student, student_id, course_id, topic_id
         if error_student:
@@ -2160,21 +2160,21 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + path_learning_element
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + path_learning_element
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2197,21 +2197,21 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    200,
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "university",
-                        "student_learning_element",
-                    ],
-                    False,
-                    False,
-                    False,
-                    False,
+                4,
+                200,
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "university",
+                    "student_learning_element",
+                ],
+                False,
+                False,
+                False,
+                False,
             ),
             # Student not found
             (1, 404, ["error", "message"], True, False, False, False),
@@ -2224,15 +2224,15 @@ class TestApi:
         ],
     )
     def test_get_le_by_id_for_student(
-            self,
-            client_class,
-            lms_user_id,
-            status_code_expected,
-            keys_expected,
-            error_student,
-            error_course,
-            error_topic,
-            error_le,
+        self,
+        client_class,
+        lms_user_id,
+        status_code_expected,
+        keys_expected,
+        error_student,
+        error_course,
+        error_topic,
+        error_le,
     ):
         global user_id_student, student_id, course_id
         global topic_id, learning_element_id
@@ -2253,23 +2253,23 @@ class TestApi:
         else:
             learning_element_id_use = learning_element_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_course
-                + "/"
-                + str(course_id_use)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + path_learning_element
-                + "/"
-                + str(learning_element_id_use)
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_course
+            + "/"
+            + str(course_id_use)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + path_learning_element
+            + "/"
+            + str(learning_element_id_use)
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2290,13 +2290,13 @@ class TestApi:
         ],
     )
     def test_get_users_by_admin_id(
-            self,
-            client_class,
-            lms_user_id,
-            keys_expected_1,
-            keys_expected_2,
-            status_code_expected,
-            error_user,
+        self,
+        client_class,
+        lms_user_id,
+        keys_expected_1,
+        keys_expected_2,
+        status_code_expected,
+        error_user,
     ):
         global user_id_admin, admin_id
         if error_user:
@@ -2304,15 +2304,15 @@ class TestApi:
         else:
             user_id_use = user_id_admin
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_admin
-                + "/"
-                + str(admin_id)
-                + path_user
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_admin
+            + "/"
+            + str(admin_id)
+            + path_user
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2336,12 +2336,12 @@ class TestApi:
         ],
     )
     def test_get_logs_by_admin_id(
-            self,
-            client_class,
-            lms_user_id,
-            keys_expected,
-            status_code_expected,
-            error_admin,
+        self,
+        client_class,
+        lms_user_id,
+        keys_expected,
+        status_code_expected,
+        error_admin,
     ):
         global user_id_admin, admin_id
         if error_admin:
@@ -2349,15 +2349,15 @@ class TestApi:
         else:
             user_id_use = user_id_admin
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_admin
-                + "/"
-                + str(admin_id)
-                + path_logs
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_admin
+            + "/"
+            + str(admin_id)
+            + path_logs
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2378,13 +2378,13 @@ class TestApi:
         ],
     )
     def test_get_courses_by_teacher_id(
-            self,
-            client_class,
-            lms_user_id,
-            keys_expected_1,
-            keys_expected_2,
-            status_code_expected,
-            error_teacher,
+        self,
+        client_class,
+        lms_user_id,
+        keys_expected_1,
+        keys_expected_2,
+        status_code_expected,
+        error_teacher,
     ):
         global user_id_teacher, teacher_id
         if error_teacher:
@@ -2392,15 +2392,15 @@ class TestApi:
         else:
             user_id_use = user_id_teacher
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_teacher
-                + "/"
-                + str(teacher_id)
-                + path_course
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_teacher
+            + "/"
+            + str(teacher_id)
+            + path_course
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2419,17 +2419,17 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    ["id", "name", "university", "lms_user_id", "role", "settings"],
-                    200,
-                    False,
+                4,
+                ["id", "name", "university", "lms_user_id", "role", "settings"],
+                200,
+                False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_get_user_by_id(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -2455,7 +2455,7 @@ class TestApi:
         ],
     )
     def test_get_user_settings_by_id(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -2463,7 +2463,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.get(url)
         assert r.status_code == status_code_expected
@@ -2472,7 +2472,22 @@ class TestApi:
             assert key in response.keys()
 
     # Get all learning element statuses for a student for a course
-    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @mock.patch(
+        "requests.get",
+        mock.Mock(
+            side_effect=lambda k: (
+                mock.Mock(
+                    status_code=200,
+                    json=lambda: {
+                        "statuses": [
+                            {"cmid": 1, "state": 0, "timecompleted": 0},
+                            {"cmid": 2, "state": 0, "timecompleted": 0},
+                        ]
+                    },
+                )
+            )
+        ),
+    )
     @pytest.mark.parametrize(
         "course_id, student_id",
         [
@@ -2480,26 +2495,42 @@ class TestApi:
             (1, 1)
         ],
     )
-    def test_get_activity_status_for_student(
-            self, client_class, course_id, student_id
-    ):
+    def test_get_activity_status_for_student(self, client_class, course_id, student_id):
         global user_id_student
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_activity_status
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_activity_status
         )
         r = client_class.get(url)
         assert r.status_code == 200
         response = json.loads(r.data.decode("utf-8").strip("\n"))
-        assert response ==  [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]
+        assert response == [
+            {"cmid": 1, "state": 0, "timecompleted": 0},
+            {"cmid": 2, "state": 0, "timecompleted": 0},
+        ]
 
     # Get all learning element statuses for a student for a course
-    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @mock.patch(
+        "requests.get",
+        mock.Mock(
+            side_effect=lambda k: (
+                mock.Mock(
+                    status_code=200,
+                    json=lambda: {
+                        "statuses": [
+                            {"cmid": 1, "state": 0, "timecompleted": 0},
+                            {"cmid": 2, "state": 0, "timecompleted": 0},
+                        ]
+                    },
+                )
+            )
+        ),
+    )
     @pytest.mark.parametrize(
         "course_id, student_id, \
                             learning_element_id",
@@ -2509,26 +2540,25 @@ class TestApi:
         ],
     )
     def test_get_activity_status_for_student_for_learning_element(
-            self, client_class, course_id, student_id, learning_element_id
+        self, client_class, course_id, student_id, learning_element_id
     ):
         global user_id_student
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + "/"
-                + "learningElementId/"
-                + str(learning_element_id)
-                + path_activity_status
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + "/"
+            + "learningElementId/"
+            + str(learning_element_id)
+            + path_activity_status
         )
         r = client_class.get(url)
         assert r.status_code == 200
         response = json.loads(r.data.decode("utf-8").strip("\n"))
-        assert response ==  [{'cmid': 2, 'state': 0, 'timecompleted': 0}]
-
+        assert response == [{"cmid": 2, "state": 0, "timecompleted": 0}]
 
     # PUT METHODS
     # Update the settings of a User
@@ -2541,32 +2571,32 @@ class TestApi:
             (4, {"theme": "dark", "pswd": "password"}, ["theme", "pswd"], 201, False),
             # User not found
             (
-                    1,
-                    {
-                        "theme": [
-                            {
-                                "color": "dark",
-                                "style": "dark",
-                                "typography": "Comic Sans",
-                                "language": "EN",
-                            }
-                        ],
-                        "password": "password",
-                    },
-                    ["error", "message"],
-                    404,
-                    True,
+                1,
+                {
+                    "theme": [
+                        {
+                            "color": "dark",
+                            "style": "dark",
+                            "typography": "Comic Sans",
+                            "language": "EN",
+                        }
+                    ],
+                    "password": "password",
+                },
+                ["error", "message"],
+                404,
+                True,
             ),
         ],
     )
     def test_update_user_settings_by_id(
-            self,
-            client_class,
-            lms_user_id,
-            request_body,
-            keys_expected,
-            status_code_expected,
-            error,
+        self,
+        client_class,
+        lms_user_id,
+        request_body,
+        keys_expected,
+        status_code_expected,
+        error,
     ):
         global user_id_student
         if error:
@@ -2574,7 +2604,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.put(url, json=request_body)
         assert r.status_code == status_code_expected
@@ -2589,91 +2619,91 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    {
-                        "perception_dimension": "SNS",
-                        "perception_value": 7,
-                        "input_dimension": "VIS",
-                        "input_value": 7,
-                        "processing_dimension": "ACT",
-                        "processing_value": 7,
-                        "understanding_dimension": "GLO",
-                        "understanding_value": 7,
-                    },
-                    [
-                        "perception_dimension",
-                        "perception_value",
-                        "input_dimension",
-                        "input_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    201,
-                    False,
+                4,
+                {
+                    "perception_dimension": "SNS",
+                    "perception_value": 7,
+                    "input_dimension": "VIS",
+                    "input_value": 7,
+                    "processing_dimension": "ACT",
+                    "processing_value": 7,
+                    "understanding_dimension": "GLO",
+                    "understanding_value": 7,
+                },
+                [
+                    "perception_dimension",
+                    "perception_value",
+                    "input_dimension",
+                    "input_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                201,
+                False,
             ),
             # User not found
             (
-                    1,
-                    {
-                        "perception_dimension": "SNS",
-                        "perception_value": 7,
-                        "input_dimension": "VIS",
-                        "input_value": 7,
-                        "processing_dimension": "ACT",
-                        "processing_value": 7,
-                        "understanding_dimension": "GLO",
-                        "understanding_value": 7,
-                    },
-                    ["error", "message"],
-                    404,
-                    True,
+                1,
+                {
+                    "perception_dimension": "SNS",
+                    "perception_value": 7,
+                    "input_dimension": "VIS",
+                    "input_value": 7,
+                    "processing_dimension": "ACT",
+                    "processing_value": 7,
+                    "understanding_dimension": "GLO",
+                    "understanding_value": 7,
+                },
+                ["error", "message"],
+                404,
+                True,
             ),
             # Empty Request body
             (4, {}, ["error", "message"], 400, False),
             # Wrong numbers in request body
             (
-                    4,
-                    {
-                        "perception_dimension": "SNS",
-                        "perception_value": 12,
-                        "input_dimension": "VIS",
-                        "input_value": 7,
-                        "processing_dimension": "ACT",
-                        "processing_value": 7,
-                        "understanding_dimension": "GLO",
-                        "understanding_value": 7,
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                4,
+                {
+                    "perception_dimension": "SNS",
+                    "perception_value": 12,
+                    "input_dimension": "VIS",
+                    "input_value": 7,
+                    "processing_dimension": "ACT",
+                    "processing_value": 7,
+                    "understanding_dimension": "GLO",
+                    "understanding_value": 7,
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
             # Wrong number of dimensions in request body
             (
-                    4,
-                    {
-                        "perception_dimension": "SNS",
-                        "perception_value": 7,
-                        "input_dimension": "VIS",
-                        "input_value": 7,
-                        "processing_dimension": "ACT",
-                        "processing_value": 7,
-                    },
-                    ["error", "message"],
-                    400,
-                    False,
+                4,
+                {
+                    "perception_dimension": "SNS",
+                    "perception_value": 7,
+                    "input_dimension": "VIS",
+                    "input_value": 7,
+                    "processing_dimension": "ACT",
+                    "processing_value": 7,
+                },
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_update_learning_style_by_student_id(
-            self,
-            client_class,
-            lms_user_id,
-            request_body,
-            keys_expected,
-            status_code_expected,
-            error,
+        self,
+        client_class,
+        lms_user_id,
+        request_body,
+        keys_expected,
+        status_code_expected,
+        error,
     ):
         global user_id_student, student_id
         if error:
@@ -2681,15 +2711,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_learning_style
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_learning_style
         )
         r = client_class.put(url, json=request_body)
         assert r.status_code == status_code_expected
@@ -2704,55 +2734,55 @@ class TestApi:
         [
             # Working Example
             (
-                    {
-                        "name": "Max Mustermann",
-                        "role": "Student",
-                        "university": "TH-AB",
-                        "settings": [
-                            {
-                                "theme": [
-                                    {
-                                        "color": "dark",
-                                        "style": "dark",
-                                        "typography": "Arial Black",
-                                        "language": "DE",
-                                    }
-                                ],
-                                "password": "password",
-                            }
-                        ],
-                    },
-                    4,
-                    ["id", "name", "university", "lms_user_id", "role", "settings"],
-                    201,
+                {
+                    "name": "Max Mustermann",
+                    "role": "Student",
+                    "university": "TH-AB",
+                    "settings": [
+                        {
+                            "theme": [
+                                {
+                                    "color": "dark",
+                                    "style": "dark",
+                                    "typography": "Arial Black",
+                                    "language": "DE",
+                                }
+                            ],
+                            "password": "password",
+                        }
+                    ],
+                },
+                4,
+                ["id", "name", "university", "lms_user_id", "role", "settings"],
+                201,
             ),
             # Missing Parameter
             (
-                    {
-                        "role": "Student",
-                        "university": "TH-AB",
-                        "settings": [
-                            {
-                                "theme": [
-                                    {
-                                        "color": "dark",
-                                        "style": "dark",
-                                        "typography": "Arial Black",
-                                        "language": "DE",
-                                    }
-                                ],
-                                "password": "password",
-                            }
-                        ],
-                    },
-                    4,
-                    ["error", "message"],
-                    400,
+                {
+                    "role": "Student",
+                    "university": "TH-AB",
+                    "settings": [
+                        {
+                            "theme": [
+                                {
+                                    "color": "dark",
+                                    "style": "dark",
+                                    "typography": "Arial Black",
+                                    "language": "DE",
+                                }
+                            ],
+                            "password": "password",
+                        }
+                    ],
+                },
+                4,
+                ["error", "message"],
+                400,
             ),
         ],
     )
     def test_update_user_from_moodle(
-            self, client_class, input, moodle_user_id, keys_expected, status_code_expected
+        self, client_class, input, moodle_user_id, keys_expected, status_code_expected
     ):
         global user_id_student
         url = path_lms_user + "/" + str(user_id_student) + "/" + str(moodle_user_id)
@@ -2769,46 +2799,46 @@ class TestApi:
         [
             # Working Example
             (
-                    {
-                        "name": "Test Course Updated",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["id", "name", "lms_id", "created_at", "created_by", "university"],
-                    201,
+                {
+                    "name": "Test Course Updated",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                ["id", "name", "lms_id", "created_at", "created_by", "university"],
+                201,
             ),
             # Missing Parameter
             (
-                    {
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["error", "message"],
-                    400,
+                {
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                ["error", "message"],
+                400,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "name": "Test Course Updated",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "01.01.2023",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    ["error", "message"],
-                    400,
+                {
+                    "name": "Test Course Updated",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "01.01.2023",
+                    "university": "TH-AB",
+                },
+                1,
+                ["error", "message"],
+                400,
             ),
         ],
     )
     def test_update_course_from_moodle(
-            self, client_class, input, moodle_course_id, keys_expected, status_code_expected
+        self, client_class, input, moodle_course_id, keys_expected, status_code_expected
     ):
         global course_id
         url = path_lms_course + "/" + str(course_id) + "/" + str(moodle_course_id)
@@ -2825,106 +2855,106 @@ class TestApi:
         [
             # Working Example for Topic
             (
-                    {
-                        "name": "Test Topic Updated",
-                        "is_topic": True,
-                        "parent_id": None,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    [
-                        "id",
-                        "name",
-                        "lms_id",
-                        "is_topic",
-                        "parent_id",
-                        "contains_le",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
-                    False,
+                {
+                    "name": "Test Topic Updated",
+                    "is_topic": True,
+                    "parent_id": None,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                [
+                    "id",
+                    "name",
+                    "lms_id",
+                    "is_topic",
+                    "parent_id",
+                    "contains_le",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
+                False,
             ),
             # Working Example for Sub-Topic
             (
-                    {
-                        "name": "Test Sub-Topic Updated",
-                        "is_topic": False,
-                        "parent_id": None,
-                        "contains_le": True,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    [
-                        "id",
-                        "name",
-                        "lms_id",
-                        "is_topic",
-                        "parent_id",
-                        "contains_le",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
-                    True,
+                {
+                    "name": "Test Sub-Topic Updated",
+                    "is_topic": False,
+                    "parent_id": None,
+                    "contains_le": True,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                [
+                    "id",
+                    "name",
+                    "lms_id",
+                    "is_topic",
+                    "parent_id",
+                    "contains_le",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
+                True,
             ),
             # Missing Parameter
             (
-                    {
-                        "is_topic": True,
-                        "parent_id": 1,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "is_topic": True,
+                    "parent_id": 1,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "name": "Test Topic Updated",
-                        "is_topic": True,
-                        "parent_id": None,
-                        "contains_le": False,
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "01-01-2023",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
-                    False,
+                {
+                    "name": "Test Topic Updated",
+                    "is_topic": True,
+                    "parent_id": None,
+                    "contains_le": False,
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "01-01-2023",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                ["error", "message"],
+                400,
+                False,
             ),
         ],
     )
     def test_update_topic_from_moodle(
-            self,
-            client_class,
-            input,
-            moodle_course_id,
-            moodle_topic_id,
-            keys_expected,
-            status_code_expected,
-            sub_topic,
+        self,
+        client_class,
+        input,
+        moodle_course_id,
+        moodle_topic_id,
+        keys_expected,
+        status_code_expected,
+        sub_topic,
     ):
         global course_id, topic_id, sub_topic_id
         if sub_topic:
@@ -2933,16 +2963,16 @@ class TestApi:
         else:
             topic_id_use = topic_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + "/"
-                + str(moodle_topic_id)
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + "/"
+            + str(moodle_topic_id)
         )
         r = client_class.put(url, json=input)
         assert r.status_code == status_code_expected
@@ -2958,92 +2988,92 @@ class TestApi:
         [
             # Working Example for LE
             (
-                    {
-                        "activity_type": "Quiz",
-                        "classification": "RQ",
-                        "name": "Test Learning Element Updated",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    1,
-                    [
-                        "id",
-                        "lms_id",
-                        "activity_type",
-                        "classification",
-                        "name",
-                        "created_by",
-                        "created_at",
-                        "university",
-                    ],
-                    201,
+                {
+                    "activity_type": "Quiz",
+                    "classification": "RQ",
+                    "name": "Test Learning Element Updated",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                1,
+                [
+                    "id",
+                    "lms_id",
+                    "activity_type",
+                    "classification",
+                    "name",
+                    "created_by",
+                    "created_at",
+                    "university",
+                ],
+                201,
             ),
             # Missing Parameter
             (
-                    {
-                        "classification": "RQ",
-                        "name": "Test Learning Element Updated",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "2018-07-21T17:32:28Z",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
+                {
+                    "classification": "RQ",
+                    "name": "Test Learning Element Updated",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "2018-07-21T17:32:28Z",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                1,
+                ["error", "message"],
+                400,
             ),
             # Parameter with wrong data type
             (
-                    {
-                        "activity_type": "Quiz",
-                        "classification": "RQ",
-                        "name": "Test Learning Element Updated",
-                        "created_by": "Maria Musterfrau",
-                        "created_at": "2023-08-01T13:37:42Z",
-                        "last_updated": "01.01.2023",
-                        "university": "TH-AB",
-                    },
-                    1,
-                    1,
-                    1,
-                    ["error", "message"],
-                    400,
+                {
+                    "activity_type": "Quiz",
+                    "classification": "RQ",
+                    "name": "Test Learning Element Updated",
+                    "created_by": "Maria Musterfrau",
+                    "created_at": "2023-08-01T13:37:42Z",
+                    "last_updated": "01.01.2023",
+                    "university": "TH-AB",
+                },
+                1,
+                1,
+                1,
+                ["error", "message"],
+                400,
             ),
         ],
     )
     def test_update_le_from_moodle(
-            self,
-            client_class,
-            input,
-            moodle_course_id,
-            moodle_topic_id,
-            moodle_learning_element_id,
-            keys_expected,
-            status_code_expected,
+        self,
+        client_class,
+        input,
+        moodle_course_id,
+        moodle_topic_id,
+        moodle_learning_element_id,
+        keys_expected,
+        status_code_expected,
     ):
         global course_id, sub_topic_id, learning_element_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
-                + "/"
-                + str(sub_topic_id)
-                + "/"
-                + str(moodle_topic_id)
-                + path_learning_element
-                + "/"
-                + str(learning_element_id)
-                + "/"
-                + str(moodle_learning_element_id)
+            path_lms_course
+            + "/"
+            + str(course_id)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
+            + "/"
+            + str(sub_topic_id)
+            + "/"
+            + str(moodle_topic_id)
+            + path_learning_element
+            + "/"
+            + str(learning_element_id)
+            + "/"
+            + str(moodle_learning_element_id)
         )
         r = client_class.put(url, json=input)
         assert r.status_code == status_code_expected
@@ -3064,7 +3094,7 @@ class TestApi:
         ],
     )
     def test_reset_user_settings(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student
         if error:
@@ -3072,7 +3102,7 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
+            path_user + "/" + str(user_id_use) + "/" + str(lms_user_id) + path_settings
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3087,24 +3117,24 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    [
-                        "id",
-                        "knowledge",
-                        "learning_analytics",
-                        "learning_strategy",
-                        "learning_style",
-                        "student_id",
-                    ],
-                    200,
-                    False,
+                4,
+                [
+                    "id",
+                    "knowledge",
+                    "learning_analytics",
+                    "learning_strategy",
+                    "learning_style",
+                    "student_id",
+                ],
+                200,
+                False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_characteristics(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3112,15 +3142,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_learning_characteristics
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_learning_characteristics
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3140,7 +3170,7 @@ class TestApi:
         ],
     )
     def test_reset_learning_analytics(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3148,15 +3178,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_learning_analytics
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_learning_analytics
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3171,28 +3201,28 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    [
-                        "id",
-                        "characteristic_id",
-                        "perception_dimension",
-                        "perception_value",
-                        "input_dimension",
-                        "input_value",
-                        "processing_dimension",
-                        "processing_value",
-                        "understanding_dimension",
-                        "understanding_value",
-                    ],
-                    200,
-                    False,
+                4,
+                [
+                    "id",
+                    "characteristic_id",
+                    "perception_dimension",
+                    "perception_value",
+                    "input_dimension",
+                    "input_value",
+                    "processing_dimension",
+                    "processing_value",
+                    "understanding_dimension",
+                    "understanding_value",
+                ],
+                200,
+                False,
             ),
             # User not found
             (1, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_style(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3200,15 +3230,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_learning_style
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_learning_style
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3223,37 +3253,37 @@ class TestApi:
         [
             # Working Example
             (
-                    4,
-                    [
-                        "att",
-                        "characteristic_id",
-                        "cogn_str",
-                        "con",
-                        "crit_rev",
-                        "eff",
-                        "elab",
-                        "ext_res_mng_str",
-                        "goal_plan",
-                        "id",
-                        "int_res_mng_str",
-                        "lit_res",
-                        "lrn_env",
-                        "lrn_w_cls",
-                        "metacogn_str",
-                        "org",
-                        "reg",
-                        "rep",
-                        "time",
-                    ],
-                    200,
-                    False,
+                4,
+                [
+                    "att",
+                    "characteristic_id",
+                    "cogn_str",
+                    "con",
+                    "crit_rev",
+                    "eff",
+                    "elab",
+                    "ext_res_mng_str",
+                    "goal_plan",
+                    "id",
+                    "int_res_mng_str",
+                    "lit_res",
+                    "lrn_env",
+                    "lrn_w_cls",
+                    "metacogn_str",
+                    "org",
+                    "reg",
+                    "rep",
+                    "time",
+                ],
+                200,
+                False,
             ),
             # User not found
             (100, ["error", "message"], 404, True),
         ],
     )
     def test_reset_learning_strategy(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3263,15 +3293,15 @@ class TestApi:
             user_id_use = user_id_student
             student_id_use = student_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id_use)
-                + path_learning_strategy
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id_use)
+            + path_learning_strategy
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3291,7 +3321,7 @@ class TestApi:
         ],
     )
     def test_reset_knowledge(
-            self, client_class, lms_user_id, keys_expected, status_code_expected, error
+        self, client_class, lms_user_id, keys_expected, status_code_expected, error
     ):
         global user_id_student, student_id
         if error:
@@ -3299,15 +3329,15 @@ class TestApi:
         else:
             user_id_use = user_id_student
         url = (
-                path_user
-                + "/"
-                + str(user_id_use)
-                + "/"
-                + str(lms_user_id)
-                + path_student
-                + "/"
-                + str(student_id)
-                + path_knowledge
+            path_user
+            + "/"
+            + str(user_id_use)
+            + "/"
+            + str(lms_user_id)
+            + path_student
+            + "/"
+            + str(student_id)
+            + path_knowledge
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3325,16 +3355,16 @@ class TestApi:
         ],
     )
     def test_delete_contact_form(
-            self, client_class, lms_user_id, user_id, status_code_expected
+        self, client_class, lms_user_id, user_id, status_code_expected
     ):
         user_id_student = user_id
         url = (
-                path_user
-                + "/"
-                + str(user_id_student)
-                + "/"
-                + str(lms_user_id)
-                + path_contactform
+            path_user
+            + "/"
+            + str(user_id_student)
+            + "/"
+            + str(lms_user_id)
+            + path_contactform
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3353,7 +3383,7 @@ class TestApi:
         ],
     )
     def test_delete_user(
-            self, client_class, moodle_user_id, keys_expected, status_code_expected, student
+        self, client_class, moodle_user_id, keys_expected, status_code_expected, student
     ):
         global user_id_student, user_id_teacher
         if student:
@@ -3385,16 +3415,16 @@ class TestApi:
         ],
     )
     def test_api_delete_le_from_moodle(
-            self,
-            client_class,
-            moodle_course_id,
-            moodle_topic_id,
-            moodle_learning_element_id,
-            keys_expected,
-            status_code_expected,
-            error_course,
-            error_topic,
-            error_le,
+        self,
+        client_class,
+        moodle_course_id,
+        moodle_topic_id,
+        moodle_learning_element_id,
+        keys_expected,
+        status_code_expected,
+        error_course,
+        error_topic,
+        error_le,
     ):
         global course_id, sub_topic_id, learning_element_id
         if error_course:
@@ -3410,21 +3440,21 @@ class TestApi:
         else:
             learning_element_id_use = learning_element_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id_use)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + "/"
-                + str(moodle_topic_id)
-                + path_learning_element
-                + "/"
-                + str(learning_element_id_use)
-                + "/"
-                + str(moodle_learning_element_id)
+            path_lms_course
+            + "/"
+            + str(course_id_use)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + "/"
+            + str(moodle_topic_id)
+            + path_learning_element
+            + "/"
+            + str(learning_element_id_use)
+            + "/"
+            + str(moodle_learning_element_id)
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3447,14 +3477,14 @@ class TestApi:
         ],
     )
     def test_api_delete_topic_from_moodle(
-            self,
-            client_class,
-            moodle_course_id,
-            moodle_topic_id,
-            keys_expected,
-            status_code_expected,
-            error_course,
-            error_topic,
+        self,
+        client_class,
+        moodle_course_id,
+        moodle_topic_id,
+        keys_expected,
+        status_code_expected,
+        error_course,
+        error_topic,
     ):
         global course_id, sub_topic_id
         if error_course:
@@ -3466,16 +3496,16 @@ class TestApi:
         else:
             topic_id_use = sub_topic_id
         url = (
-                path_lms_course
-                + "/"
-                + str(course_id_use)
-                + "/"
-                + str(moodle_course_id)
-                + path_topic
-                + "/"
-                + str(topic_id_use)
-                + "/"
-                + str(moodle_topic_id)
+            path_lms_course
+            + "/"
+            + str(course_id_use)
+            + "/"
+            + str(moodle_course_id)
+            + path_topic
+            + "/"
+            + str(topic_id_use)
+            + "/"
+            + str(moodle_topic_id)
         )
         r = client_class.delete(url)
         assert r.status_code == status_code_expected
@@ -3495,7 +3525,7 @@ class TestApi:
         ],
     )
     def test_api_delete_course_from_moodle(
-            self, client_class, moodle_course_id, keys_expected, status_code_expected, error
+        self, client_class, moodle_course_id, keys_expected, status_code_expected, error
     ):
         global course_id
         if error:

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2471,7 +2471,7 @@ class TestApi:
             assert key in response.keys()
 
     # Get all learning element statuses for a student for a course
-    #@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
     @pytest.mark.parametrize(
         "course_id, student_id",
         [

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2495,7 +2495,38 @@ class TestApi:
         r = client_class.get(url)
         assert r.status_code == 200
         response = json.loads(r.data.decode("utf-8").strip("\n"))
-        assert "cmid" in response.statuses[0].keys()
+        assert response ==  [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]
+
+    # Get all learning element statuses for a student for a course
+    @mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+    @pytest.mark.parametrize(
+        "course_id, student_id",
+        [
+            # Working Example
+            (1, 1, 2)
+        ],
+    )
+    def test_get_activity_status_for_student_for_learning_element(
+            self, client_class, course_id, student_id, learning_element_id
+    ):
+        global user_id_student
+        url = (
+                path_lms_course
+                + "/"
+                + str(course_id)
+                + path_student
+                + "/"
+                + str(student_id)
+                + "learningElementId/"
+                + str(learning_element_id)
+                + "/"
+                + path_activity_status
+        )
+        r = client_class.get(url)
+        assert r.status_code == 200
+        response = json.loads(r.data.decode("utf-8").strip("\n"))
+        assert response ==  [{'cmid': 2, 'state': 0, 'timecompleted': 0}]
+
 
     # PUT METHODS
     # Update the settings of a User

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1950,12 +1950,12 @@ def test_create_course():
     "requests.get",
     mock.Mock(
         side_effect=lambda k: (
-                mock.Mock(
-                    status_code=200,
-                    json=lambda: {
-                        "statuses": [{"cmid": 1, "state": 0, "timecompleted": 0}]
-                    },
-                )
+            mock.Mock(
+                status_code=200,
+                json=lambda: {
+                    "statuses": [{"cmid": 1, "state": 0, "timecompleted": 0}]
+                },
+            )
         )
     ),
 )
@@ -1969,7 +1969,7 @@ def test_get_moodle_rest_url_for_completion_status():
         course_id=1,
         student_id=1,
     )
-    assert result == {'statuses': [{"cmid": 1, "state": 0, "timecompleted": 0}]}
+    assert result == {"statuses": [{"cmid": 1, "state": 0, "timecompleted": 0}]}
 
 
 @mock.patch(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from unittest.mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,8 +9,6 @@ import repositories.repository as repository
 import service_layer.crypto.JWTKeyManagement as JWTKeyManagement
 from domain.userAdministartion import model as UA
 from service_layer import services, unit_of_work
-from service_layer.services import get_moodle_rest_url_for_completion_status, \
-    get_activity_status_for_student_for_course, get_activity_status_for_student_for_learning_element_for_course
 from utils import constants as cons
 
 
@@ -861,45 +859,6 @@ class FakeRepository(repository.AbstractRepository):  # pragma: no cover
             if i.university == university:
                 result.append(i)
         return result
-
-    def mock_unit_of_work(self):
-        return Mock()
-
-    @pytest.fixture
-    def mock_response(self):
-        response = Mock()
-        response.status_code = 200
-        response.json.return_value = {"statuses": [
-            {"cmid":405,"state":1,"timecompleted":1699966649},
-            {"cmid":406,"state":1,"timecompleted":1699966666}
-        ]}
-        return response
-
-    @patch("your_module.requests.get")
-    def test_get_moodle_rest_url_for_completion_status(mock_get, mock_unit_of_work, mock_response):
-        mock_get.return_value = mock_response
-        result = get_moodle_rest_url_for_completion_status(mock_unit_of_work, "course_id", "student_id")
-        assert result == mock_response
-        mock_get.assert_called_once_with(
-            "your_moodle_url/webservice/rest/server.php"
-            "?wsfunction=core_completion_get_activities_completion_status"
-            "&wstoken=your_rest_token&moodlewsrestformat=json&courseid=your_course_id&userid=student_id"
-        )
-
-    @patch("your_module.requests.get")
-    def test_get_activity_status_for_student_for_course(mock_get, mock_unit_of_work, mock_response):
-        mock_get.return_value = mock_response
-        result = get_activity_status_for_student_for_course(mock_unit_of_work, "course_id", "student_id")
-        assert result == []
-        mock_get.assert_called_once()
-
-    @patch("your_module.get_activity_status_for_student_for_course")
-    def test_get_activity_status_for_student_for_learning_element_for_course(mock_get_activity_status, mock_unit_of_work):
-        mock_get_activity_status.return_value = [{"cmid": 1, "state": 1, "timecompleted": 12345}]
-        result = get_activity_status_for_student_for_learning_element_for_course(mock_unit_of_work, "course_id", "student_id", "1")
-        assert result == [{"cmid": 1, "state": 1, "timecompleted": 12345}]
-        mock_get_activity_status.assert_called_once_with(mock_unit_of_work, "course_id", "student_id")
-
 
     def update_course(self, course_id, course):
         to_remove = next((p for p in self.course if p.id == course_id), None)
@@ -1984,6 +1943,18 @@ def test_create_course():
         entries_beginning_course_creator_course + 1
         == entries_after_course_creator_course
     )
+
+
+def test_get_moodle_rest_url_for_completion_status():
+    uow = FakeUnitOfWork()
+    create_course_creator_for_tests(uow)
+    create_course_for_tests(uow)
+    result = services.get_moodle_rest_url_for_completion_status(
+        uow=uow,
+        course_id=1,
+        student_id=1,
+    )
+    print(result)
 
 
 def test_get_course_by_id():

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,7 +1,7 @@
 import datetime
 import time
-from unittest.mock import MagicMock, patch, Mock
-import os
+from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import pytest
 
@@ -1946,19 +1946,17 @@ def test_create_course():
     )
 
 
-def test_get_moodle_rest_url_for_completion_status(mocker):
-    mocker.patch('requests.get', return_value=Mock(status_code=200, json=lambda: {"statuses": []}))
+@mock.patch('requests.get', mock.Mock(side_effect = lambda k:{'cmid': 1, 'state': 0, 'timecompleted': 0}.get(k, 'unhandled request %s'%k)))
+def test_get_moodle_rest_url_for_completion_status():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
     create_course_for_tests(uow)
-    mocker.patch.dict(os.environ, {'REST_LMS_URL': 'your_mocked_url', 'REST_TOKEN': 'your_mocked_token'})
 
     result = services.get_moodle_rest_url_for_completion_status(
         uow=uow,
         course_id=1,
         student_id=1,
     )
-    print(result)
 
 
 def test_get_course_by_id():

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1946,7 +1946,10 @@ def test_create_course():
     )
 
 
-@mock.patch('requests.get', mock.Mock(side_effect = lambda k:[{'cmid': 1, 'state': 0, 'timecompleted': 0}]))
+@mock.patch(
+    "requests.get",
+    mock.Mock(side_effect=lambda k: [{"cmid": 1, "state": 0, "timecompleted": 0}]),
+)
 def test_get_moodle_rest_url_for_completion_status():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
@@ -1957,10 +1960,25 @@ def test_get_moodle_rest_url_for_completion_status():
         course_id=1,
         student_id=1,
     )
-    assert (result == [{'cmid': 1, 'state': 0, 'timecompleted': 0}])
+    assert result == [{"cmid": 1, "state": 0, "timecompleted": 0}]
 
 
-@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+@mock.patch(
+    "requests.get",
+    mock.Mock(
+        side_effect=lambda k: (
+            mock.Mock(
+                status_code=200,
+                json=lambda: {
+                    "statuses": [
+                        {"cmid": 1, "state": 0, "timecompleted": 0},
+                        {"cmid": 2, "state": 0, "timecompleted": 0},
+                    ]
+                },
+            )
+        )
+    ),
+)
 def test_get_activity_status_for_student_for_course():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
@@ -1971,10 +1989,28 @@ def test_get_activity_status_for_student_for_course():
         course_id=1,
         student_id=1,
     )
-    assert (result == [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}])
+    assert result == [
+        {"cmid": 1, "state": 0, "timecompleted": 0},
+        {"cmid": 2, "state": 0, "timecompleted": 0},
+    ]
 
 
-@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+@mock.patch(
+    "requests.get",
+    mock.Mock(
+        side_effect=lambda k: (
+            mock.Mock(
+                status_code=200,
+                json=lambda: {
+                    "statuses": [
+                        {"cmid": 1, "state": 0, "timecompleted": 0},
+                        {"cmid": 2, "state": 0, "timecompleted": 0},
+                    ]
+                },
+            )
+        )
+    ),
+)
 def test_get_activity_status_for_student_for_learning_element_for_course():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
@@ -1986,7 +2022,7 @@ def test_get_activity_status_for_student_for_learning_element_for_course():
         student_id=1,
         learning_element_id=2,
     )
-    assert (result == [{'cmid': 2, 'state': 0, 'timecompleted': 0}])
+    assert result == [{"cmid": 2, "state": 0, "timecompleted": 0}]
 
 
 def test_get_course_by_id():

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,7 +1,7 @@
 import datetime
 import time
-from unittest.mock import MagicMock, patch
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1946,7 +1946,7 @@ def test_create_course():
     )
 
 
-@mock.patch('requests.get', mock.Mock(side_effect = lambda k:{'cmid': 1, 'state': 0, 'timecompleted': 0}.get(k, 'unhandled request %s'%k)))
+@mock.patch('requests.get', mock.Mock(side_effect = lambda k:[{'cmid': 1, 'state': 0, 'timecompleted': 0}]))
 def test_get_moodle_rest_url_for_completion_status():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
@@ -1957,6 +1957,7 @@ def test_get_moodle_rest_url_for_completion_status():
         course_id=1,
         student_id=1,
     )
+    assert (result == [{'cmid': 1, 'state': 0, 'timecompleted': 0}])
 
 
 def test_get_course_by_id():

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1960,6 +1960,35 @@ def test_get_moodle_rest_url_for_completion_status():
     assert (result == [{'cmid': 1, 'state': 0, 'timecompleted': 0}])
 
 
+@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+def test_get_activity_status_for_student_for_course():
+    uow = FakeUnitOfWork()
+    create_course_creator_for_tests(uow)
+    create_course_for_tests(uow)
+
+    result = services.get_activity_status_for_student_for_course(
+        uow=uow,
+        course_id=1,
+        student_id=1,
+    )
+    assert (result == [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}])
+
+
+@mock.patch('requests.get', mock.Mock(side_effect=lambda k: (mock.Mock(status_code=200, json=lambda: {"statuses": [{'cmid': 1, 'state': 0, 'timecompleted': 0}, {'cmid': 2, 'state': 0, 'timecompleted': 0}]}))))
+def test_get_activity_status_for_student_for_learning_element_for_course():
+    uow = FakeUnitOfWork()
+    create_course_creator_for_tests(uow)
+    create_course_for_tests(uow)
+
+    result = services.get_activity_status_for_student_for_learning_element_for_course(
+        uow=uow,
+        course_id=1,
+        student_id=1,
+        learning_element_id=2,
+    )
+    assert (result == [{'cmid': 2, 'state': 0, 'timecompleted': 0}])
+
+
 def test_get_course_by_id():
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -2016,7 +2016,7 @@ def test_get_activity_status_for_student_for_learning_element_for_course():
     create_course_creator_for_tests(uow)
     create_course_for_tests(uow)
 
-    result = services.get_activity_status_for_student_for_learning_element_for_course(
+    result = services.get_activity_status_for_learning_element(
         uow=uow,
         course_id=1,
         student_id=1,

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,6 +1,7 @@
 import datetime
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, Mock
+import os
 
 import pytest
 
@@ -1945,10 +1946,13 @@ def test_create_course():
     )
 
 
-def test_get_moodle_rest_url_for_completion_status():
+def test_get_moodle_rest_url_for_completion_status(mocker):
+    mocker.patch('requests.get', return_value=Mock(status_code=200, json=lambda: {"statuses": []}))
     uow = FakeUnitOfWork()
     create_course_creator_for_tests(uow)
     create_course_for_tests(uow)
+    mocker.patch.dict(os.environ, {'REST_LMS_URL': 'your_mocked_url', 'REST_TOKEN': 'your_mocked_token'})
+
     result = services.get_moodle_rest_url_for_completion_status(
         uow=uow,
         course_id=1,

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1948,7 +1948,16 @@ def test_create_course():
 
 @mock.patch(
     "requests.get",
-    mock.Mock(side_effect=lambda k: [{"cmid": 1, "state": 0, "timecompleted": 0}]),
+    mock.Mock(
+        side_effect=lambda k: (
+                mock.Mock(
+                    status_code=200,
+                    json=lambda: {
+                        "statuses": [{"cmid": 1, "state": 0, "timecompleted": 0}]
+                    },
+                )
+        )
+    ),
 )
 def test_get_moodle_rest_url_for_completion_status():
     uow = FakeUnitOfWork()
@@ -1960,7 +1969,7 @@ def test_get_moodle_rest_url_for_completion_status():
         course_id=1,
         student_id=1,
     )
-    assert result == [{"cmid": 1, "state": 0, "timecompleted": 0}]
+    assert result == {'statuses': [{"cmid": 1, "state": 0, "timecompleted": 0}]}
 
 
 @mock.patch(


### PR DESCRIPTION
Added
- 2 Entrypoints 
- 2 service methods.

One will request all learning element status of a student for a course and return all after filtering for {cmid: Learning Element Id, state: State of the Elemenet (completed 1 or uncompleted 0), timecompleted: unix time of done status}

The other one will request all learning element status and return only one after filtering for a specific Learning Element Id (cmid) 