### PR TITLE
Random Pickup of LEs that have equal Probability + UnitTests

### DIFF
--- a/domain/tutoringModel/NestorFolder/nestor_utils.py
+++ b/domain/tutoringModel/NestorFolder/nestor_utils.py
@@ -1,6 +1,12 @@
+import random
+from collections import defaultdict
+
 from pgmpy.estimators import ExpectationMaximization as EM
 from pgmpy.models import BayesianNetwork
 
+from domain.tutoringModel.utils import ran_seed
+
+random.seed(ran_seed)
 # Helper functions
 
 
@@ -28,6 +34,37 @@ def categorize_lisk_bfi(input_dataframe, encoding_columns):
                 ]
 
     return input_dataframe
+
+
+def randomize_same_values(sorted_dict):
+    """
+    This function takes a dictionary sorted in descending order by its values.
+    It randomizes the order of keys that have the same value while maintaining
+    the overall descending order of different values.
+    """
+    # the probability values have string datatype
+    # Convert string values to floats for comparison and sorting
+    float_dict = {k: float(v) for k, v in sorted_dict.items()}
+
+    # Group keys by their float values into a defaultdict(list)
+    value_groups = defaultdict(list)
+    for key, value in float_dict.items():
+        value_groups[value].append(key)
+
+    # Shuffle the keys within each group of the same value
+    for key_group in value_groups.values():
+        random.shuffle(key_group)
+
+    # Reconstruct the dictionary in descending order by value,
+    # keeping the randomized order within groups
+    randomized_sorted_dict = {}
+    # Sort and iterate in descending order
+    for value in sorted(value_groups.keys(), reverse=True):
+        for key in value_groups[value]:
+            # Convert values back to strings
+            randomized_sorted_dict[key] = str(value)
+
+    return randomized_sorted_dict
 
 
 def build_bn(edges_list):

--- a/domain/tutoringModel/nestor.py
+++ b/domain/tutoringModel/nestor.py
@@ -5,7 +5,7 @@ import random
 from pgmpy.inference import VariableElimination
 from pgmpy.readwrite import XMLBIFReader
 
-from domain.tutoringModel.utils import ran_seed
+from domain.tutoringModel.NestorFolder import nestor_utils
 from errors import errors as err
 from utils import constants as cons
 
@@ -21,7 +21,7 @@ class Nestor:
         All the global values used in Nestor
         are initiated here.
         """
-        random.seed(ran_seed)
+        # random.seed(ran_seed)
         # the following dict maps
         # output variables' states of the
         # trained BN with their respective
@@ -103,7 +103,7 @@ class Nestor:
         of learner
         to recommend personalized learning paths
         """
-        random.seed(ran_seed)
+        # random.seed(ran_seed)
         # defining the path to saved BN
         # path_to_model = path_to_model
         # The HASKI Gemeninsam uses the Learning styles naming convention of
@@ -199,12 +199,13 @@ class Nestor:
 
         # here the dictionary contains inference with both yes and no
         # The LEs with state 'No' is not removed but
-        # probability for state 'yes' is calculated
+        # probability for state to be 'yes' is calculated
         le_max_dict = {
             key: str(round(1 - float(val), 1)) if "No" in key else val
             for key, val in le_max_dict.items()
         }
-
+        # soring LEs in descending order, randomizing same value LEs
+        le_max_dict = nestor_utils.randomize_same_values(le_max_dict)
         # Get items from the input_dict and
         # sort them based on the numerical values in descending order
         sorted_items = sorted(

--- a/tests/unit/test_tutoring_model.py
+++ b/tests/unit/test_tutoring_model.py
@@ -400,9 +400,16 @@ def test_prepare_les_for_nestor(learning_style):
         )
         list_of_les.append(le.serialize())
     lp = TM.LearningPath(student_id=1, course_id=1, based_on="nestor")
+    lp2 = TM.LearningPath(student_id=3, course_id=1, based_on="nestor")
 
     lp.get_learning_path(
         student_id=1,
+        learning_style=learning_style,
+        _algorithm="nestor",
+        list_of_les=list_of_les,
+    )
+    lp2.get_learning_path(
+        student_id=3,
         learning_style=learning_style,
         _algorithm="nestor",
         list_of_les=list_of_les,
@@ -411,7 +418,12 @@ def test_prepare_les_for_nestor(learning_style):
     # all Learning styles is Forum
     # Unit testing the result for dummy LS and LE
     result = lp.path
-    assert result[:2] == "FO"
+    # Unit test result to check if the LP's elements occur in retrived result
+    result2 = lp2.path
+
+    assert result[:2] in ("LZ", "FO")
+    for ele in result2:
+        assert ele in ("FO, ÜB, KÜ, ZF, EK, AN, ZL, LZ")
 
     nestor_alg = nestor.Nestor()
     # unit test for learning path returned from nestor inference


### PR DESCRIPTION
The previous push had a missing function which should randomize the sequence of learning elements which has an equal probability of recommendation. This causes the Nestor to behave in a deterministic manner. This pull request updates the respective Nestor files. 
