### PR TITLE
chore: Update Dockerfile for improved build process and runtime efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,27 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.10.4-slim-buster
+# Builder stage
+FROM python:3.10.4-slim-buster AS builder
+
+WORKDIR /build
+COPY ./requirements.txt /build/
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy the source code and other necessary files
+COPY domain/ /build/domain/
+COPY entrypoints/ /build/entrypoints/
+COPY repositories/ /build/repositories/
+COPY service_layer/ /build/service_layer/
+COPY setup/ /build/setup/
+COPY tests/ /build/tests/
+COPY utils/ /build/utils/
+COPY config.py /build/
+COPY errors/ /build/errors/
+
+# Runtime stage
+FROM python:3.10.4-slim-buster AS runtime
 
 WORKDIR /app
+COPY --from=builder /build /app
 
-COPY ./requirements.txt /app/requirements.txt
-
-RUN pip3 install -r requirements.txt
-
-#Copying only needed folders/files to image
-
-COPY domain/ /app/domain/
-
-COPY entrypoints/ /app/entrypoints/
-
-COPY repositories/ /app/repositories/
-
-COPY service_layer/ /app/service_layer/
-
-COPY setup/ /app/setup/
-
-COPY tests/ /app/tests/
-
-COPY utils/ /app/utils/
-
-COPY config.py /app/config.py
-
-COPY errors/ /app/errors/
-
-CMD [ "python3", "-m" , "flask", "run", "--host=0.0.0.0"]
+CMD ["python3", "-m", "flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
- added multistage docker build
- runtime image is smaller
- image was 8GB before and is 119MB now