### PR TITLE
Haski requirements linking tests

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -661,6 +661,7 @@ class TestApi:
         status_code_expected,
         save_id,
     ):
+        """[HASKI-REQ-0036] Validates topic and subtopic creation from Moodle payloads."""
         global course_id, topic_id, sub_topic_id
         url = path_lms_course + "/" + str(course_id) + path_topic
         if topic_id != 0:


### PR DESCRIPTION
This pull request enhances the clarity and maintainability of the end-to-end API tests in `tests/e2e/test_api.py`. The main improvements include the addition of descriptive docstrings referencing requirements for key test cases and consistent formatting of long lines for better readability.

**Test documentation improvements:**

* Added requirement-referenced docstrings to major test methods for user, course, and topic creation from Moodle payloads, improving traceability and clarity of test purposes. [[1]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecR380) [[2]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecR459) [[3]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecR535) [[4]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecR664)

**Code formatting and readability:**

* Reformatted long lines in test methods to use multi-line string concatenation, enhancing readability and consistency across API endpoint constructions. [[1]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL1235-R1240) [[2]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL1408-R1414) [[3]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL1887-R1894) [[4]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL2034-R2042) [[5]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL2329-R2338) [[6]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL3564-R3574) [[7]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL3776-R3787) [[8]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL3812-R3824) [[9]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL3993-R4006) [[10]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4050-R4064) [[11]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4116-R4131) [[12]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4237-R4253) [[13]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4446-R4463) [[14]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4474-R4492) [[15]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4762-R4781) [[16]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4845-R4865) [[17]](diffhunk://#diff-68bcc6076eecf5703da1ace7fd5a517aab6ab1d993bfef3dd960c9bb011380ecL4871-R4892)