### PR TITLE
test: add pytest_json_runtest_metadata to attach test docstrings to J…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,3 +29,13 @@ def client(session_factory):  # pragma: no cover
     with app.app_context():
         with app.test_client() as client:
             yield client
+
+
+def pytest_json_runtest_metadata(item, call):
+    """Attach test docstrings to the JSON report entries."""
+    if call.when != "call":
+        return {}
+    docstring = getattr(getattr(item, "function", None), "__doc__", None)
+    if not docstring:
+        return {}
+    return {"docstring": docstring.strip()}


### PR DESCRIPTION
…SON report
This pull request introduces an enhancement to the test reporting functionality by adding support for including test docstrings in the JSON report. This makes it easier to understand the purpose of each test directly from the report.

Test reporting improvements:

* Added the `pytest_json_runtest_metadata` hook to `tests/conftest.py`, which attaches each test’s docstring to its corresponding entry in the JSON report. This helps provide more context and documentation for test results.